### PR TITLE
change dbnsfp separator to &

### DIFF
--- a/dbNSFP.pm
+++ b/dbNSFP.pm
@@ -301,7 +301,7 @@ sub run {
   
   # get required data
   my %return =
-    map {$_ => $data->{$_}}
+    map {$_ => ($data->{$_} =~ s/[|]/&/gr) } # replace | with & to prevent conflict with existing field sep
     map {$data->{$_} =~ s/\;/\,/g; $_ }
     grep {$data->{$_} ne '.'}              # ignore missing data
     grep {defined($self->{cols}->{$_})}  # only include selected cols


### PR DESCRIPTION
Clinvar fields returned from dbnsfp can contain | symbols, which conflicts with the | separator already used to separate fields by VEP.

This change replaces |s with &s.

This resolves https://github.com/Ensembl/VEP_plugins/issues/6