### PR TITLE
Fix dbNSFP parse the wrong readme file

### DIFF
--- a/dbNSFP.pm
+++ b/dbNSFP.pm
@@ -145,7 +145,7 @@ sub get_header_info {
       $file_dir =~ s/\/[^\/]+$/\//;
 
       if(opendir DIR, $file_dir) {
-        my ($readme_file) = grep {/dbnsfp.*readme/i} readdir DIR;
+        my ($readme_file) = grep {/dbnsfp.*readme\.txt/i} readdir DIR;
         closedir DIR;
 
         if(open RM, $file_dir.$readme_file) {


### PR DESCRIPTION
When the user is using dbNSFP version 2.9.1, there might be a file called "search_dbNSFP291.readme.pdf" which causes the plugin to parse the pdf file instead of the correct file.