### PR TITLE
Increase ExAC plugin speed, fix missed ExAC annotations, and add option to skip non-PASS ExAC variants

### DIFF
--- a/ExAC.pm
+++ b/ExAC.pm
@@ -18,7 +18,7 @@ limitations under the License.
 =head1 CONTACT
 
  Will McLaren <wm2@ebi.ac.uk>
-    
+
 =cut
 
 =head1 NAME
@@ -38,13 +38,13 @@ limitations under the License.
 =head1 DESCRIPTION
 
  A VEP plugin that retrieves ExAC allele frequencies.
- 
+
  Visit ftp://ftp.broadinstitute.org/pub/ExAC_release/current to download the latest ExAC VCF.
- 
+
  Note that the currently available version of the ExAC data file (0.3) is only available
  on the GRCh37 assembly; therefore it can only be used with this plugin when using the
  VEP on GRCh37. See http://www.ensembl.org/info/docs/tools/vep/script/vep_other.html#assembly
- 
+
  The tabix utility must be installed in your path to use this plugin.
 
  The plugin takes 3 command line arguments. Second and third arguments are not mandatory. If AC specified as second
@@ -68,12 +68,12 @@ use base qw(Bio::EnsEMBL::Variation::Utils::BaseVepPlugin);
 
 sub new {
   my $class = shift;
-  
+
   my $self = $class->SUPER::new(@_);
-  
+
   # test tabix
   die "ERROR: tabix does not seem to be in your path\n" unless `which tabix 2>&1` =~ /tabix$/;
-  
+
   # get ExAC file
   my $file = $self->params->[0];
 
@@ -105,9 +105,12 @@ sub new {
     die "ERROR: ExAC file $file not found; you can download it from ftp://ftp.broadinstitute.org/pub/ExAC_release/current\n" unless -e $file;
     die "ERROR: Tabix index file $file\.tbi not found - perhaps you need to create it first?\n" unless -e $file.'.tbi';
   }
-  
+
+  # initialize current iteration of ExAC file
+  $self->{exac_state} = {chr => "", pos => 0};
+
   $self->{file} = $file;
-  
+
   return $self;
 }
 
@@ -117,20 +120,20 @@ sub feature_types {
 
 sub get_header_info {
   my $self = shift;
-  
+
   if(!exists($self->{header_info})) {
     open IN, "tabix -f -h ".$self->{file}." 1:1-1 |";
-    
+
     my %headers = ();
     my @lines = <IN>;
-    
+
     while(my $line = shift @lines) {
       if($line =~ /ID\=AC(\_[A-Zdj]+)?\,.*\"(.+)\"/) {
         my ($pop, $desc) = ($1, $2);
-        
+
         $desc =~ s/Counts?/frequency/i;
         $pop ||= '';
-        
+
         my $field_name = 'ExAC_AF'.$pop;
         $headers{$field_name} = 'ExAC '.$desc;
 
@@ -147,134 +150,200 @@ sub get_header_info {
         push @{$self->{headers}}, 'AC'.$pop;
       }
     }
-    
+
     close IN;
-    
+
     die "ERROR: No valid headers found in ExAC VCF file\n" unless scalar keys %headers;
-    
+
     $self->{header_info} = \%headers;
   }
-  
+
   return $self->{header_info};
+}
+
+
+# given a pair of alleles, return the shortest Ensembl-like representation and
+# adjust the starting coordindate if necessary.
+# operates on references to the alleles and position!
+sub fix_alleles {
+  my ($ref, $alt, $start) = @_;
+
+  # if the first base is the same, trim it and adjust starting coord
+  if (substr($$ref, 0, 1) eq substr($$alt, 0, 1)) {
+    $$ref = substr($$ref, 1) || "-";
+    $$alt = substr($$alt, 1) || "-";
+    $$start += 1;
+  }
+
+  # remove any identical sequence of bases from the end of the alleles
+  while (substr($$ref, -1) eq substr($$alt, -1)) {
+    $$ref = substr($$ref, 0, -1) || "-";
+    $$alt = substr($$alt, 0, -1) || "-";
+  }
+}
+
+
+# read ExAC file up to the position of the current variant feature and store
+# the parsed ExAC data in the cache.
+sub process_exac {
+  my ($self, $vf) = @_;
+
+  # if we're on a new chromosome or at a position we've already passed, open up a new file descriptor
+  if ($vf->{chr} ne $self->{exac_state}->{chr} || $vf->{start} < $self->{exac_state}->{last_vf_start}) {
+
+    close($self->{exac_state}->{fp}) if defined $self->{exac_state}->{fp};
+
+    # we can skip directly to the first requested position (helpful for parallelization)
+    open $self->{exac_state}->{fp}, sprintf("tabix -f %s %s:%s |", $self->{file}, $vf->{chr}, $vf->{start} - 1);
+
+    # update state and empty cache
+    $self->{exac_state}->{chr} = $vf->{chr};
+    $self->{exac_state}->{pos} = 0;
+    $self->{cache} = [];
+  }
+
+  $self->{exac_state}->{last_vf_start} = $vf->{start};
+
+  # keep only cache entries that are at or ahead of the current variant feature
+  # subtract one from starting position to account for indels
+  # (a A/- Ensembl variant at position 10 might be a CA/C variant at position 9
+  # in ExAC)
+  $self->{cache} = [ grep { $_->{pos} >= $vf->{start} - 1 } @{$self->{cache}} ];
+
+  # main ExAC parsing loop
+  # iterate over ExAC file until we reach the position of the current variation
+  # feature or we run out of ExAC variants
+  while ($self->{exac_state}->{pos} < $vf->{start} && !eof($self->{exac_state}->{fp})) {
+
+    $_ = readline $self->{exac_state}->{fp};
+    chomp;
+    s/\r$//;
+
+    my @fields = split /\s+/;
+    my $chr = $fields[0];
+    my $start = $fields[1];
+    my $ref = $fields[3];
+    my @alts = split /,/, $fields[4];
+    my $info = $fields[7];
+
+    # if the variant is not at the position of the variation feature (accounting
+    # for indels), don't parse it further
+    next unless $start >= $vf->{start} - 1;
+
+    $self->{exac_state}->{chr} = $chr;
+    $self->{exac_state}->{pos} = $start;
+
+    # map of unfixed ExAC alternate allele to hash of frequency data
+    my %data = map { $_ => {} } @alts;
+
+    # iterate over required headers
+    foreach my $h(@{$self->{headers} || []}) {
+      my $total_ac = 0;
+
+      if ($info =~ /$h=([0-9,]+)/) {
+
+        # grab AC
+        my @ac = split /,/, $1;
+        next unless scalar @ac == scalar @alts;
+
+        # now sed header to get AN
+        my $anh = $h;
+        $anh =~ s/AC/AN/;
+
+        my $afh = $h;
+        $afh =~ s/AC/AF/;
+
+        # get AC from header
+        my $ach = $h;
+
+        if ($info =~ /$anh=([0-9,]+)/) {
+
+          # grab AN
+          my @an = split /,/, $1;
+          next unless @an;
+          my $an;
+
+          foreach my $a(@alts) {
+
+            my $ac = shift @ac;
+            $an = shift @an if @an;
+
+            # no dividing by 0
+            next unless $an;
+
+            $total_ac += $ac;
+            if ($self->{display_ac}) {
+              $data{$a}->{'ExAC_'.$ach} = $ac;
+            }
+            if ($self->{display_an}) {
+              $data{$a}->{'ExAC_'.$anh} = $an;
+            }
+
+            $data{$a}->{'ExAC_'.$afh} = sprintf("%.3g", $ac / $an);
+          }
+        }
+      }
+    }
+
+    # store data in cache using fixed alleles (fixed for each ref/alt pair)
+    foreach my $a(@alts) {
+      my $a_ref = $ref;
+      my $a_alt = $a;
+      my $a_pos = $start;
+      fix_alleles(\$a_ref, \$a_alt, \$a_pos);
+
+      push @{$self->{cache}}, {chr => $chr, pos => $a_pos, ref => $a_ref, alt => $a_alt, data => $data{$a}};
+    }
+  }
 }
 
 sub run {
   my ($self, $tva) = @_;
 
+
   # make sure headers have been loaded
   $self->get_header_info();
 
   my $vf = $tva->variation_feature;
-  
+
   # get allele, reverse comp if needed
   my $allele;
-  
+
   $allele = $tva->variation_feature_seq;
   reverse_comp(\$allele) if $vf->{strand} < 0;
-  
-  # adjust coords to account for VCF-like storage of indels
-  my ($s, $e) = ($vf->{start} - 1, $vf->{end} + 1);
-  
-  my $pos_string = sprintf("%s:%i-%i", $vf->{chr}, $s, $e);
-  
-  # clear cache if it looks like the coords are the same
-  # but allele type is different
-  delete $self->{cache} if
-    defined($self->{cache}->{$pos_string}) &&
-    scalar keys %{$self->{cache}->{$pos_string}} &&
-    !defined($self->{cache}->{$pos_string}->{$allele});
-  
+
+  # continue iteration of ExAC until we get to our variation feature position
+  $self->process_exac($vf);
+
+  my @alleles = split /\//, $vf->allele_string;
+  my $ref = shift @alleles;
+
   my $data = {};
-  
-  # cached?
-  if(defined($self->{cache}) && defined($self->{cache}->{$pos_string})) {
-    $data = $self->{cache}->{$pos_string};
-  }
-  
-  # read from file
-  else {
-    open TABIX, sprintf("tabix -f %s %s |", $self->{file}, $pos_string);
-    
-    while(<TABIX>) {
-      chomp;
-      s/\r$//g;
-      
-      # parse VCF line into a VariationFeature object
-      my ($vcf_vf) = @{parse_line({format => 'vcf'}, $_)};
-      
-      # check parsed OK
-      next unless $vcf_vf && $vcf_vf->isa('Bio::EnsEMBL::Variation::VariationFeature');
-      
-      # compare coords
-      next unless $vcf_vf->{start} == $vf->{start} && $vcf_vf->{end} == $vf->{end};
-      
-      # get alleles, shift off reference
-      my @vcf_alleles = split /\//, $vcf_vf->allele_string;
-      my $ref_allele = shift @vcf_alleles;
-      
-      # iterate over required headers
-      HEADER:
-      foreach my $h(@{$self->{headers} || []}) {
-        my $total_ac = 0;
-        
-        if(/$h\=([0-9\,]+)/) {
-          
-          # grab AC
-          my @ac = split /\,/, $1;
-          next unless scalar @ac == scalar @vcf_alleles;
-          
-          # now sed header to get AN
-          my $anh = $h;
-          $anh =~ s/AC/AN/;
-          
-          my $afh = $h;
-          $afh =~ s/AC/AF/;
 
-          # get AC from header
-          my $ach = $h;
+  # search cache for data corresponding to fixed alleles (for each ref/alt pair)
+  for my $a(@alleles) {
+    my $a_ref = $ref;
+    my $a_alt = $a;
+    my $a_pos = $vf->{start};
+    fix_alleles(\$a_ref, \$a_alt, \$a_pos);
 
-          if(/$anh\=([0-9\,]+)/) {
-            
-            # grab AN
-            my @an = split /\,/, $1;
-            next unless @an;
-            my $an;
+    # find cache hits
+    my @hits = grep {
+      $_->{chr} eq $vf->{chr} &&
+      $_->{pos} == $a_pos &&
+      $_->{ref} eq $a_ref &&
+      $_->{alt} eq $a_alt
+    } @{$self->{cache}};
 
-            foreach my $a(@vcf_alleles) {
-              my $ac = shift @ac;
-              $an = shift @an if @an;
-              next HEADER unless $an;
+    # there should never be more than one
+    if (scalar @hits) {
+      my $hit = shift @hits;
 
-              $total_ac += $ac;
-              if ($self->{display_ac}){
-                $data->{$a}->{'ExAC_'.$ach} = $ac;
-              }
-              if ($self->{display_an}){
-                $data->{$a}->{'ExAC_'.$anh} = $an;
-              }
-
-              $data->{$a}->{'ExAC_'.$afh} = sprintf("%.3g", $ac / $an);
-            }
-            
-            # use total to get ref allele freq
-            if ($self->{display_ac}){
-             $data->{$ref_allele}->{'ExAC_'.$ach} = $total_ac;
-            }
-            if ($self->{display_an}){
-              $data->{$ref_allele}->{'ExAC_'.$anh} = $an;
-            }
-            $data->{$ref_allele}->{'ExAC_'.$afh} = sprintf("%.3g", 1 - ($total_ac / $an));
-          }
-        }
-      }
+      # store it using the unfixed Ensembl allele, used for lookup at the end
+      $data->{$a} = $hit->{data};
     }
-    
-    close TABIX;
   }
-  
-  # overwrite cache
-  $self->{cache} = {$pos_string => $data};
-  
+
   return defined($data->{$allele}) ? $data->{$allele} : {};
 }
 


### PR DESCRIPTION
I run VEP on large, genome-scale VCFs and I've noticed that the ExAC plugin drastically increases processing times. There is a quicker `--maf_exac` VEP option but unfortunately this does not do any matching based on alleles, as I understand it.

This patch decreases total VEP run times by **10-15x** on my machines when using the ExAC plugin with sorted VCFs. Instead of opening the ExAC VCF once per variation feature, the ExAC VCF is opened only once per chromosome and iterated at the same time as the VCF being annotated when the VCF is sorted. In the case of unsorted VCFs, the ExAC VCF is re-opened whenever a variation feature that occurs before the previous feature is encountered. Performance is improved relative to the original plugin even when I tested annotation of shuffled VCFs, however the performance increase isn't as great as it is for sorted VCFs.

This patch also improves allele matching between the ExAC VCF and the annotated VCF, which causes problems primarily for multiallelic sites.

Consider this ExAC record:

`1 138829 . GC TC,G`

And a VCF with this record:

`1 138829 . G T`

This record would not have been annotated because the alleles do not match exactly. This patch instead transforms each ref/alt allele pair into a minimal representation to make the comparison. In my tests, as many as **6%** of the variants in my VCFs that exist in ExAC were not being annotated.

This patch also introduces an option to skip non-PASS ExAC variants.
