### PR TITLE
NearestGene: Fix "ERROR: Could not get gene adaptor"

### DIFF
--- a/NearestGene.pm
+++ b/NearestGene.pm
@@ -101,6 +101,7 @@ sub run {
   my $loc_string = sprintf("%s:%i-%i", $vf->{chr} || $vf->seq_region_name, $vf->{start}, $vf->{end});
   
   if(!exists($self->{_cache}) || !exists($self->{_cache}->{$loc_string})) {
+    $self->{config}->{ga} = $self->{config}->{reg}->get_adaptor($self->{config}->{species}, $self->{config}->{core_type}, 'gene');
     $self->{ga} ||= $self->{config}->{ga};
     die("ERROR: Could not get gene adaptor; this plugin does not work in --offline mode\n") unless $self->{ga};
 


### PR DESCRIPTION
NearestGene plugin doesn't work neither inside docker container provided.

This is my fix, I don't know Perl and VEP code but I hope that be useful.

Regards.