### PR TITLE
Change to current argument set

### DIFF
--- a/Downstream.pm
+++ b/Downstream.pm
@@ -116,7 +116,7 @@ sub run {
         }
         
         # translate
-        my $new_pep = $codon_seq->translate(undef, undef, undef, $codon_table)->seq();
+        my $new_pep = $codon_seq->translate(-codontable_id => $codon_table)->seq();
         $new_pep =~ s/\*.*//;
         
         # compare lengths


### PR DESCRIPTION
Changing the argument set for Bio::PrimarySeqI::translate from the deprecated set used before 1.5.1 to the current one. There's no reason to believe users will still be using this ancient version of VEP.