### PR TITLE
LRG_RefSeqGene

### DIFF
--- a/LRG_RefSeqGene.pm
+++ b/LRG_RefSeqGene.pm
@@ -68,8 +68,13 @@ sub new {
 
   open(my $fh, $file) or die $!;
 
+  chomp(my $header_line = <$fh>);
+  $header_line =~ s/^#\s*//;
+
   my $tsv = Text::CSV->new({ binary => 1, auto_diag => 1, sep_char => "\t" });
-  $tsv->column_names($tsv->getline($fh));
+
+  $tsv->parse($header_line);
+  $tsv->column_names($tsv->fields);
 
   my %data;
 


### PR DESCRIPTION
Hi, we have added some code to retrieve the [LRG_RefSeqGene](https://www.ncbi.nlm.nih.gov/refseq/rsg/lrg) category. This is useful when working with [ClinVar](https://www.ncbi.nlm.nih.gov/clinvar/docs/faq/) to be able to see which transcripts have been selected as reference standards by the LRG. We do wonder though if there's a better way to obtain these values, as there doesn't appear to be any way to get a particular version of the LRG_RefSeqGene file. Any comments/suggestions would be much appreciated.