### PR TITLE
calculate for more than one population

### DIFF
--- a/LD.pm
+++ b/LD.pm
@@ -166,10 +166,10 @@ sub new {
   $pop_name ||= '1000GENOMES:phase_3:CEU';
 
   my @pop_names = ();
-
   if ($pop_name =~ /^populations=/) {
     $pop_name =~ s/populations=//;  
-    push @pop_names, split('&', $pop_name);
+    my %unique_populations = map { $_ => 1 } split('&', $pop_name);
+    push @pop_names, keys %unique_populations;
   } else {
     push @pop_names, $pop_name;
   }


### PR DESCRIPTION
Changes for #125 The plugin can take more than one population as argument. Add some code for backwards compatibility. If only one population is used use the same results key (LinkedVariants) as before. I also updated the caching of already computed results.

Some test data is under our panda variation space: variation/data/VEP_plugins/