### PR TITLE
af_from_vcf option cannot be run in offline mode

### DIFF
--- a/G2P.pm
+++ b/G2P.pm
@@ -228,6 +228,7 @@ sub new {
   }
 
   if ($params->{af_from_vcf}) {
+    die "option 'af_from_vcf' cannot be run in --offline mode" if (defined $self->{config}->{offline});
     if ($CAN_USE_HTS_PM) {
       my @vcf_collection_ids = ();
       my $assembly =  $self->{config}->{assembly};

--- a/G2P.pm
+++ b/G2P.pm
@@ -228,7 +228,7 @@ sub new {
   }
 
   if ($params->{af_from_vcf}) {
-    die "option 'af_from_vcf' cannot be run in --offline mode" if (defined $self->{config}->{offline});
+    die "option 'af_from_vcf' cannot be run in --offline mode\n" if (defined $self->{config}->{offline});
     if ($CAN_USE_HTS_PM) {
       my @vcf_collection_ids = ();
       my $assembly =  $self->{config}->{assembly};
@@ -703,9 +703,9 @@ sub read_gene_data_from_file {
   $fh->close();
   if ($file_type eq 'unknown') {
     if ($file =~ /gz$/) { 
-      die("ERROR: G2P plugin can only read uncompressed data");
+      die("ERROR: G2P plugin can only read uncompressed data\n");
     } else {
-      die("ERROR: Could not recognize input file format. Format must be one of panelapp, g2p or custom. Check website for details: https://www.ebi.ac.uk/gene2phenotype/g2p_vep_plugin");
+      die("ERROR: Could not recognize input file format. Format must be one of panelapp, g2p or custom. Check website for details: https://www.ebi.ac.uk/gene2phenotype/g2p_vep_plugin\n");
     }
   }
 
@@ -816,7 +816,7 @@ sub write_report {
   my $flag = shift;
   my $log_dir = $self->{user_params}->{log_dir};
   my $log_file = "$log_dir/$$.txt";
-  open(my $fh, '>>', $log_file) or die "Could not open file '$flag $log_file' $!";
+  open(my $fh, '>>', $log_file) or die "Could not open file '$flag $log_file' $!\n";
   if ($flag eq 'G2P_list') {
     my ($gene_symbol, $DDD_category) = @_;
     $DDD_category ||= 'Not assigned';


### PR DESCRIPTION
G2P can be run in offline mode but only use annotations from cache files then. af_from_vcf option which allows to get annotations from additional VCF files doesn't work in offline mode. First of all because it it needs the VCFCollectionAdaptor from a registry object which I cannot get in offline mode. Same PR is coming for postreleasefix/98.