### PR TITLE
use correct transcript variation alt allele

### DIFF
--- a/CADD.pm
+++ b/CADD.pm
@@ -103,7 +103,7 @@ sub run {
     my $matches = get_matched_variant_alleles(
       {
         ref    => $vf->ref_allele_string,
-        alts   => $vf->alt_alleles,
+        alts   => [$allele],
         pos    => $vf->{start},
         strand => $vf->strand
       },


### PR DESCRIPTION
Fix for https://www.ebi.ac.uk/panda/jira/browse/ENSVAR-2365
Problem was that the variation_feature alt alleles were used which for a G/A/C/T variant is always A/C/T.