### PR TITLE
remove extra section in phenotypes

### DIFF
--- a/plugin_config.txt
+++ b/plugin_config.txt
@@ -746,7 +746,6 @@ my $VEP_PLUGIN_CONFIG = {
       "requires_data" => 1,
       "available" => 0,
       "enabled" => 0,
-      "section" => "Phenotype",
       "plugin_url" => "https://raw.githubusercontent.com/Ensembl/VEP_plugins/release/98/Phenotypes.pm",
       "params" => [
         #"/path/to/Phenotypes_data_files/phenotypes_dir_with_dumps_for_all_species.gvf.gz"


### PR DESCRIPTION
Test web vep form has the phenotype checkbox mangled. The cause is the duplicate section entry. "Phenotype Data" section is used in the web form, while "Phenotype" for the web docs.
sandbox: http://ves-hx2-76.ebi.ac.uk:6080/Multi/Tools/VEP?db=core