### PR TITLE
Delete prefix 'chr' from chromosome 98 

### DIFF
--- a/Conservation.pm
+++ b/Conservation.pm
@@ -188,11 +188,10 @@ sub run {
     return {};
   }
 
-  if($vf->{chr} =~ /^chr/) {
-    $vf->{chr} =~ s/^chr//i;
-  }
+  my $chr = $vf->{chr};
+  $chr =~ s/^chr//i;
 
-  $parser->seek($vf->{chr}, $vf->{start} - 1, $vf->{end});
+  $parser->seek($chr, $vf->{start} - 1, $vf->{end});
   $parser->next;  
 
   return $parser->get_raw_score ? { Conservation => sprintf("%.3f", $parser->get_raw_score)} : {};

--- a/Conservation.pm
+++ b/Conservation.pm
@@ -188,6 +188,10 @@ sub run {
     return {};
   }
 
+  if($vf->{chr} =~ /^chr/) {
+    $vf->{chr} =~ s/^chr//i;
+  }
+
   $parser->seek($vf->{chr}, $vf->{start} - 1, $vf->{end});
   $parser->next;  
 


### PR DESCRIPTION
Conservation plugin can't handle prefix 'chr' (#261). 