### PR TITLE
check that vf start does not go below 1

### DIFF
--- a/CADD.pm
+++ b/CADD.pm
@@ -92,7 +92,9 @@ sub run {
   
   return {} unless $allele =~ /^[ACGT-]+$/;
 
-  my @data =  @{$self->get_data($vf->{chr}, $vf->{start} - 2, $vf->{end})};
+  my $vf_start = $vf->{start};
+  $vf_start = ($vf_start <= 2) ? 1 : $vf_start - 2; 
+  my @data =  @{$self->get_data($vf->{chr}, $vf_start, $vf->{end})};
 
   foreach (@data) {
     my $matches = get_matched_variant_alleles(


### PR DESCRIPTION
Bio/EnsEMBL/Variation/Utils/BaseVepTabixPlugin.pm::get_data throws an error if start is 0 (vep issue 678). I can reproduce the error with VCF formatted variant  '17 2 . N A id . .'. At the moment I don't know why we are subtracting 2 from the vf_start before passing it to get_data(). For now I'm only checking that the start doesn't get smaller than 1 which works. I need to apply that fix also to 98, 99 and postreleasefix/100.