### PR TITLE
Fix SV overlap custom field

### DIFF
--- a/StructuralVariantOverlap.pm
+++ b/StructuralVariantOverlap.pm
@@ -224,7 +224,7 @@ sub run {
 
     if(scalar (keys %{$self->{cols}}) > 0){
       foreach my $info (keys %{$self->{cols}}){
-        push @{$save{$self->{label} . $info}},  $info{$info};
+        push @{$save{$self->{label} . "_" . $info}},  $info{$info};
       }
     }
     else{


### PR DESCRIPTION
Issue #280 
There's a missing column in the output file when using option 'cols=AF'. 