### PR TITLE
support different 4.x versions

### DIFF
--- a/dbNSFP.pm
+++ b/dbNSFP.pm
@@ -143,10 +143,10 @@ sub new {
   my $version;
   if ($file =~ /2\.9/) {
     $version = '2.9';
-  } elsif ($file =~ /4\.0b1/) {
+  } elsif ($file =~ /4\.0b1/) { # we need to treat this version as a special case because the name of the location column is different from other releases
     $version = '4.0.1';
-  } elsif ($file =~ /4\.0/) {
-    $version = '4.0';
+  } elsif ($file =~ /4\./) {
+    $version = '4';
   } elsif ($file =~ /3\./) {
     $version = 3;
   } else {


### PR DESCRIPTION
Support newer 4.x versions. I tested with version 4.1a(PANDA/anja/dbNSFP_tests/dbNSFP_4.1a_grch38.sh) and 4.0a(PANDA/anja/dbNSFP_tests/dbNSFP_4.0a_grch38.sh).
Longterm we need to clean up the logic for checking the version.

I will create a PR against postreleasefix/102 too.