### PR TITLE
Fix - CADD -1 strand

### DIFF
--- a/CADD.pm
+++ b/CADD.pm
@@ -93,7 +93,6 @@ sub run {
   
   # get allele, reverse comp if needed
   my $allele = $tva->variation_feature_seq;
-  reverse_comp(\$allele) if $vf->{strand} < 0;
   
   return {} unless $allele =~ /^[ACGT-]+$/;
 

--- a/CADD.pm
+++ b/CADD.pm
@@ -91,7 +91,7 @@ sub run {
   
   my $vf = $tva->variation_feature;
   
-  # get allele, reverse comp if needed
+  # get allele
   my $allele = $tva->variation_feature_seq;
   
   return {} unless $allele =~ /^[ACGT-]+$/;


### PR DESCRIPTION
The `get_matched_variant_alleles` takes into consideration the ref/alt and strand information. The removed line was redundant and only reversing the alt allele while the strand and ref allele were still the original values.
Test script and results before/after in PANDA/data/VEP_plugins/vep_CADD_grch38.sh

Example: 
rs183413880 (+ strand) and NM_181426.2:c.1073C>T (- strand) expected to retrieve same CADD scores as both notations refer to same variation.