### PR TITLE
DisGeNET add species

### DIFF
--- a/plugin_config.txt
+++ b/plugin_config.txt
@@ -935,6 +935,9 @@ my $VEP_PLUGIN_CONFIG = {
       "section" => "Phenotype data",
       "available" => 0,
       "enabled" => 0,
+      "species" => [
+        "homo_sapiens"
+      ],
       "plugin_url" => "https://raw.githubusercontent.com/Ensembl/VEP_plugins/release/102/DisGeNET.pm",
     },
 


### PR DESCRIPTION
Adding the species fixes the plugin display in non-human species. 
ENSWEB-6073 
Sandbox: http://ves-hx2-76.ebi.ac.uk:7040/Homo_sapiens/Tools/VEP?db=core;tl=S0dJ89tbHAfoAxaH-341 