### PR TITLE
Add species info to Mastermind and DisGeNET

### DIFF
--- a/plugin_config.txt
+++ b/plugin_config.txt
@@ -935,6 +935,9 @@ my $VEP_PLUGIN_CONFIG = {
       "section" => "Phenotype data and citations",
       "available" => 0,
       "enabled" => 0,
+      "species" => [
+        "homo_sapiens"
+      ],
       "plugin_url" => "https://raw.githubusercontent.com/Ensembl/VEP_plugins/release/103/DisGeNET.pm",
     },
 
@@ -945,6 +948,9 @@ my $VEP_PLUGIN_CONFIG = {
       "helptip" => "Variants with clinical evidence cited in the medical literature reported by Mastermind Genomic Search Engine (https://www.genomenon.com/mastermind)",
       "available" => 0,
       "enabled" => 0,
+      "species" => [
+        "homo_sapiens"
+      ],
       "section" => "Phenotype data and citations",
       "plugin_url" => "https://raw.githubusercontent.com/Ensembl/VEP_plugins/release/103/Mastermind.pm"
     },


### PR DESCRIPTION
The species info affects the web vep display. These two plugins should only be available for human. 
Sandbox: http://ves-hx2-76.ebi.ac.uk:7040/Homo_sapiens/Tools/VEP?db=core;tl=S0dJ89tbHAfoAxaH-341