### PR TITLE
Change DisGeNET output structure

### DIFF
--- a/DisGeNET.pm
+++ b/DisGeNET.pm
@@ -207,9 +207,13 @@ sub run {
 
   my %hash;
   my @final_result;
+  my @final_result_json;
+
+  my $format = $self->{config}->{output_format};
 
   foreach my $data_value (@data) {
     my @result;
+    my %result_json;
 
     my $pmid = $data_value->{pmid};
     my $rsid = $data_value->{rsid};
@@ -226,28 +230,44 @@ sub run {
       next if(!$check);
     }
 
-    push @result, $pmid;
-    push @result, $score;
+    if($format eq 'json') {
+      $result_json{'pmid'} = $pmid;
+      $result_json{'score'} = $score;
+    }
+    else {
+      push @result, $pmid;
+      push @result, $score;
+    }
 
     if($self->{disease}) {
-      push @result, $data_value->{diseaseName};
+      if($format eq 'json') {
+        $result_json{'diseaseName'} = $data_value->{diseaseName};
+      }
+      else {
+        push @result, $data_value->{diseaseName};
+      }
     }
 
     if($self->{rsid}) {
-      push @result, $rsid;
+      if($format eq 'json') {
+        $result_json{'rsid'} = $rsid;
+      }
+      else {
+        push @result, $rsid;
+      }
     }
 
-    push @final_result, join(':', @result);
-
+    if($format eq 'json') {
+      push @final_result_json, \%result_json;
+    }
+    else {
+      push @final_result, join(':', @result);
+    }
   }
 
-  # return the unique results
-  my %h1 = map{ $_ => 1 }@final_result;
-  my @new_final_result = keys %h1;
+  $hash{"DisGeNET"} = [@final_result];
 
-  $hash{"DisGeNET"} = [@new_final_result];
-
-  return \%hash;
+  return $format eq 'json' ? {DisGeNET => [@final_result_json]} : \%hash;
 }
 
 sub parse_data {

--- a/DisGeNET.pm
+++ b/DisGeNET.pm
@@ -175,15 +175,17 @@ sub get_header_info {
 
   my %header;
 
-  $header{"DisGeNET"} = "The different elements are separated by ':'. PMID of the publication reporting the Variant-Disease association; DisGeNET score for the Variant-Disease association";
+  $header{"DisGeNET"} = "Variant-Disease-PMID associations from the DisGeNET database. The output includes the PMID of the publication reporting the Variant-Disease association, DisGeNET score for the Variant-Disease association";
 
   if($self->{disease}) {
-    $header{"DisGeNET"} = $header{"DisGeNET"} . "; Name of associated disease";
+    $header{"DisGeNET"} .= ", name of associated disease";
   }
 
   if($self->{rsid}) {
-    $header{"DisGeNET"} = $header{"DisGeNET"} . "; dbSNP variant Identifier";
+    $header{"DisGeNET"} .= ", dbSNP variant Identifier";
   }
+
+  $header{"DisGeNET"} .= ". Each value is separated by ':'";
 
   return \%header;
 }


### PR DESCRIPTION
The current output structure is confusing. There's no way to associate the PMID with the scores because we have a different list for each: one list with all PMIDs, another with scores and so on. 

In the new structure each element is:
`pmid:score` 
`pmid:score:phenotype:rsid`

Example input: rs699

ENSVAR-3968