### PR TITLE
use ensembl assigned stable_id

### DIFF
--- a/G2P.pm
+++ b/G2P.pm
@@ -773,7 +773,7 @@ sub dump_individual_annotations {
   my $vf_cache_name = $self->{vf_cache_name};
   my $transcript = $tva->transcript;
   my $transcript_stable_id = $transcript->stable_id;
-  my $gene_stable_id = $transcript->{_gene_stable_id};
+  my $gene_stable_id = $transcript->{_gene}->stable_id;
   $self->write_report('G2P_individual_annotations', join("\t", $gene_stable_id, $transcript_stable_id, $vf_cache_name, $zyg, $individual));
 }
 


### PR DESCRIPTION
$transcript->{_gene_stable_id} stores the db primary accession as assigned by NCBI for RefSeq genes. $transcript->{_gene}->stable_id stores the stable id from the gene table as assigned by ensembl. Use the latter for consistency across the plugin when storing gene related data. I will create similar PRs for 101, 102 and 103. For 104 I will create a separate method get_gene_symbol_id to make it easier to control how the the gene_stable_id is retrieved. Test data and script are stored under PANDA/variation/G2P/test_data_pr_gene_symbol_id
ENSVAR-4054