### PR TITLE
support latest REVEL files with grch38 positions

### DIFF
--- a/REVEL.pm
+++ b/REVEL.pm
@@ -99,10 +99,13 @@ sub new {
 
   my $assembly = $self->{config}->{assembly};
 
-  foreach my $assembly_to_pos (['GRCh37', 'hg19_pos'], ['GRCh38', 'grch38_pos']) {
-    if ($assembly eq  $assembly_to_pos->[0] && ! grep {$_ eq  $assembly_to_pos->[1]} @{$self->{headers}}) {
-      die "ERROR: Assembly is " . $assembly_to_pos->[0] . " but REVEL file does not contain " . $assembly_to_pos->[1] . " in header.\n"; 
-    }
+  my %assembly_to_hdr = ('GRCh37' => 'hg19_pos',
+                         'GRCh38' => 'grch38_pos');
+
+  if (! grep {$_ eq $assembly_to_hdr{$assembly}} @{$self->{headers}}) {
+      die "ERROR: Assembly is " . $assembly .
+          " but REVEL file does not contain " .
+          $assembly_to_hdr{$assembly} . " in header.\n";
   }
 
   my ($start_key, $end_key) = ('start_grch38', 'end_grch38');

--- a/REVEL.pm
+++ b/REVEL.pm
@@ -150,7 +150,7 @@ sub parse_data {
         REVEL   => $revel_value,
       }
     };
-  } 
+  }
   # the first version only has GRCh37 coordinates
   elsif ($self->{revel_file_columns} == 7) {
     my ($c, $s, $ref, $alt, $refaa, $altaa, $revel_value) = @values;

--- a/REVEL.pm
+++ b/REVEL.pm
@@ -98,10 +98,18 @@ sub new {
   $self->{revel_file_columns} = $column_count;
 
   my $assembly = $self->{config}->{assembly};
+
+  foreach my $assembly_to_pos (['GRCh37', 'hg19_pos'], ['GRCh38', 'grch38_pos']) {
+    if ($assembly eq  $assembly_to_pos->[0] && ! grep {$_ eq  $assembly_to_pos->[1]} @{$self->{headers}}) {
+      die "ERROR: Assembly is " . $assembly_to_pos->[0] . " but REVEL file does not contain " . $assembly_to_pos->[1] . " in header.\n"; 
+    }
+  }
+
   my ($start_key, $end_key) = ('start_grch38', 'end_grch38');
   if ($assembly eq 'GRCh37') {
     ($start_key, $end_key) = ('start_grch37', 'end_grch37');
   }
+
   $self->{revel_start_key} = $start_key;
   $self->{revel_end_key} = $end_key;
 


### PR DESCRIPTION
Newer version of REVEL also contains GRCh38 positions. Update the plugin to work with the new files, but also still support the older REVEL files.
Issue has been reported here #397
New files are under PANDA/data/REVEL/2020-feb
