### PR TITLE
Updating mtr required file

### DIFF
--- a/DisGeNET.pm
+++ b/DisGeNET.pm
@@ -126,8 +126,6 @@ sub new {
 
   my $param_hash = $self->params_to_hash();
 
-  die("ERROR: DisGeNET file not provided or not found!\n") unless defined($param_hash->{file}) && -e $param_hash->{file};
-
   $self->add_file($param_hash->{file});
 
   if(defined($param_hash->{disease})) {

--- a/MTR.pm
+++ b/MTR.pm
@@ -69,12 +69,6 @@ sub new {
     }
   }
 
-  # check files exist
-  else {
-    die "ERROR: MTR file $file not found\n" unless -e $file;
-    die "ERROR: Tabix index file $file\.tbi not found - perhaps you need to create it first?\n" unless -e $file.'.tbi';
-  }
-
   # get headers and store on self
   open HEAD, "tabix -fh $file 1:1-1 2>&1 | ";
   while(<HEAD>) {

--- a/Mastermind.pm
+++ b/Mastermind.pm
@@ -130,7 +130,7 @@ sub new {
 
   $self->get_user_params();
   my $file = $self->params->[0]
-  $self->add_file($self->params->[0]);
+  $self->add_file($file);
 
   if(defined($self->params->[1])) {
     $self->{mutation_off} = $self->params->[1];

--- a/Mastermind.pm
+++ b/Mastermind.pm
@@ -129,9 +129,7 @@ sub new {
   $self->expand_right(0);
 
   $self->get_user_params();
-
-  die("ERROR: Mastermind input file not specified or found!\n") unless defined($self->params->[0]) && -e $self->params->[0];
-
+  my $file = $self->params->[0]
   $self->add_file($self->params->[0]);
 
   if(defined($self->params->[1])) {

--- a/Mastermind.pm
+++ b/Mastermind.pm
@@ -129,7 +129,7 @@ sub new {
   $self->expand_right(0);
 
   $self->get_user_params();
-  my $file = $self->params->[0]
+  my $file = $self->params->[0];
   $self->add_file($file);
 
   if(defined($self->params->[1])) {

--- a/SpliceAI.pm
+++ b/SpliceAI.pm
@@ -129,8 +129,6 @@ sub new {
 
   my $param_hash = $self->params_to_hash();
 
-  die("ERROR: SpliceAI files not provided or not found!\n") unless defined($param_hash->{snv}) && defined($param_hash->{indel}) && -e $param_hash->{snv} && -e $param_hash->{indel};
-
   $self->add_file($param_hash->{snv});
   $self->add_file($param_hash->{indel});
 


### PR DESCRIPTION
The MTR plugin data has been moved to a different website. This PR was made to update the docs on how to download and tabix the downloaded files and also check for assembly as it only works for GRCh37. 
The files used for testing are rsid - rs699 and the VCF files /hps/nobackup2/production/ensembl/olaaustine/TestDataEMC1_grch37.vcf
Also the file and the tbi indexed file can be found in /hps/nobackup2/production/ensembl/TestData/ olaaustine/mtrflatfile_2.0.tsv.gz