### PR TITLE
Check if CADD plugin arguments are Tabix-indexed files

### DIFF
--- a/CADD.pm
+++ b/CADD.pm
@@ -73,7 +73,9 @@ sub new {
 
   # Check files in arguments
   my @params = @{$self->params};
-  die "ERROR: No CADD files specified\n" unless @params > 0;
+  die "ERROR: No CADD files specified\n" .
+    "Tip: Add CADD files as plugin parameters, e.g.:\n" .
+    "  ./vep -i variations.vcf --plugin CADD,/path/to/whole_genome_SNVs.tsv.gz,/path/to/InDels.tsv.gz\n" unless @params > 0;
   $self->add_file($_) for @params;
 
   return $self;

--- a/CADD.pm
+++ b/CADD.pm
@@ -71,6 +71,11 @@ sub new {
 
   $self->get_user_params();
 
+  # Check files in arguments
+  my @params = @{$self->params};
+  die "ERROR: No CADD files specified" unless @params > 0;
+  $self->add_file($_) for @params;
+
   return $self;
 }
 

--- a/CADD.pm
+++ b/CADD.pm
@@ -73,7 +73,7 @@ sub new {
 
   # Check files in arguments
   my @params = @{$self->params};
-  die "ERROR: No CADD files specified" unless @params > 0;
+  die "ERROR: No CADD files specified\n" unless @params > 0;
   $self->add_file($_) for @params;
 
   return $self;

--- a/plugin_config.txt
+++ b/plugin_config.txt
@@ -690,7 +690,6 @@ my $VEP_PLUGIN_CONFIG = {
     # https://github.com/ensembl-variation/VEP_plugins/blob/master/CADD.pm
     # Requires tabix-indexed data file as first param
     # No other parameters so no form required
-    # data file currently only available for GRCh37
     {
       "key" => "CADD",
       "label" => "CADD",


### PR DESCRIPTION
Added safeguards to check if files are valid, similar to #458.

Also removed comment stating that CADD files were only available for GRCh37.