### PR TITLE
Improve GO plugin: GRCh38 fix + offline mode support

### DIFF
--- a/GO.pm
+++ b/GO.pm
@@ -258,11 +258,11 @@ sub _generate_gff {
       ) AS attribute
       
     FROM transcript
-    JOIN translation ON translation.transcript_id = transcript.transcript_id
-    JOIN object_xref ox ON $id = ox.ensembl_id
-    JOIN xref x ON ox.xref_id = x.xref_id
-    JOIN seq_region sr ON transcript.seq_region_id = sr.seq_region_id
-    JOIN external_db db ON x.external_db_id = db.external_db_id
+    LEFT JOIN translation ON translation.transcript_id = transcript.transcript_id
+    LEFT JOIN object_xref ox ON $id = ox.ensembl_id
+    LEFT JOIN xref x ON ox.xref_id = x.xref_id
+    LEFT JOIN seq_region sr ON transcript.seq_region_id = sr.seq_region_id
+    LEFT JOIN external_db db ON x.external_db_id = db.external_db_id
     WHERE db.db_name = "GO"
     GROUP BY transcript.stable_id
     ORDER BY sr.name, transcript.seq_region_start, transcript.seq_region_end;

--- a/GO.pm
+++ b/GO.pm
@@ -261,7 +261,7 @@ sub _generate_gff {
     JOIN xref x ON ox.xref_id = x.xref_id
     JOIN seq_region sr ON transcript.seq_region_id = sr.seq_region_id
     JOIN external_db db ON x.external_db_id = db.external_db_id
-    WHERE db.db_name = "GO"
+    WHERE db.db_name = "GO" AND db.dbprimary_acc LIKE "GO:%"
     ORDER BY transcript.stable_id, # major assumption for the next steps
              x.display_label
   };

--- a/GO.pm
+++ b/GO.pm
@@ -235,10 +235,12 @@ sub _generate_gff {
   my $ta = $self->{config}->{reg}->get_adaptor($species, 'Core', 'Transcript');
   die ("ERROR: Ensembl core database not available\n") unless defined $ta;
   
-  # Check whether GO terms are related with transcript or translation
+  # Check whether GO terms are set at transcript or translation level
   my $id = _get_GO_terms_id( $ta );
   
   # Query database and write to GFF file
+  my $join_translation_table = _starts_with($id, "translation") ?
+    "JOIN translation ON translation.transcript_id = transcript.transcript_id" : "";
   my @query = qq{
     SELECT
       sr.name AS seqname,
@@ -258,11 +260,11 @@ sub _generate_gff {
       ) AS attribute
       
     FROM transcript
-    LEFT JOIN translation ON translation.transcript_id = transcript.transcript_id
-    LEFT JOIN object_xref ox ON $id = ox.ensembl_id
-    LEFT JOIN xref x ON ox.xref_id = x.xref_id
-    LEFT JOIN seq_region sr ON transcript.seq_region_id = sr.seq_region_id
-    LEFT JOIN external_db db ON x.external_db_id = db.external_db_id
+    $join_translation_table
+    JOIN object_xref ox ON $id = ox.ensembl_id
+    JOIN xref x ON ox.xref_id = x.xref_id
+    JOIN seq_region sr ON transcript.seq_region_id = sr.seq_region_id
+    JOIN external_db db ON x.external_db_id = db.external_db_id
     WHERE db.db_name = "GO"
     GROUP BY transcript.stable_id
     ORDER BY sr.name, transcript.seq_region_start, transcript.seq_region_end;
@@ -282,6 +284,11 @@ sub _generate_gff {
 
   print "### GO plugin: GFF file ready!\n" unless $config->{quiet};
   return 1;
+}
+
+sub _starts_with {
+  my ($string, $prefix) = @_;
+  return rindex($string, $prefix, 0) == 0;
 }
 
 sub _get_GO_terms_id {

--- a/GO.pm
+++ b/GO.pm
@@ -32,8 +32,8 @@ limitations under the License.
 
 =head1 DESCRIPTION
 
- A VEP plugin that retrieves Gene Ontology terms associated with
- transcripts/translations via the Ensembl API. Requires database connection.
+ A VEP plugin that retrieves Gene Ontology terms associated with transcripts
+ (GRCh38) or their translations (GRCh37). Requires database connection.
  
 =cut
 
@@ -81,7 +81,7 @@ sub feature_types {
 }
 
 sub get_header_info {
-  return { 'GO' => 'GO terms associated with protein product'};
+  return { 'GO' => 'GO terms associated with transcript or protein product'};
 }
 
 sub run {
@@ -90,7 +90,7 @@ sub run {
   # Get GO terms from translation level if not available from transcript level
   my $tr = $tva->transcript;
   my $entries = _get_GO_terms( $tr );
-  $entries = _get_GO_terms( $tr->translation ) unless @$entries;
+  $entries = _get_GO_terms( $tr->translation ) unless defined(@$entries);
   return {} unless defined(@$entries);
   
   my $string = join(",", map {$_->display_id.':'.$_->description} @$entries);
@@ -101,7 +101,7 @@ sub run {
 
 sub _get_GO_terms {
   my $tr = shift;
-  return [] unless defined( $tr );
+  return undef unless defined( $tr );
   return $tr->get_all_DBEntries('GO');
 }
 

--- a/GO.pm
+++ b/GO.pm
@@ -306,7 +306,8 @@ sub _remote_run {
   my $string = join(",", @go_terms);
   $string =~ s/\s+/\_/g;
   
-  return { GO => $string };
+  # Avoid returning empty GO terms
+  return $string eq "" ? {} : { GO => $string };
 }
 
 sub _uniq {

--- a/GO.pm
+++ b/GO.pm
@@ -73,7 +73,7 @@ sub new {
 }
 
 sub version {
-  return 73;
+  return 107;
 }
 
 sub feature_types {
@@ -87,15 +87,22 @@ sub get_header_info {
 sub run {
   my ($self, $tva) = @_;
   
-  my $tr = $tva->transcript->translation;
-  return {} unless defined($tr);
-  
-  my $entries = $tr->get_all_DBEntries('GO');
+  # Get GO terms from translation level if not available from transcript level
+  my $tr = $tva->transcript;
+  my $entries = _get_GO_terms( $tr );
+  $entries = _get_GO_terms( $tr->translation ) unless @$entries;
+  return {} unless defined(@$entries);
   
   my $string = join(",", map {$_->display_id.':'.$_->description} @$entries);
   $string =~ s/\s+/\_/g;
   
   return { GO => $string };
+}
+
+sub _get_GO_terms {
+  my $tr = shift;
+  return [] unless defined( $tr );
+  return $tr->get_all_DBEntries('GO');
 }
 
 1;

--- a/GO.pm
+++ b/GO.pm
@@ -210,6 +210,8 @@ sub _prepare_filename {
   my $species  = $config->{species};
   my $version  = $config->{db_version} || $reg->software_version;
   my $assembly = $config->{assembly};
+  die "specify assembly using --assembly [assembly]\n" unless defined($assembly);
+
   my @basename = ($pkg, $species, $version);
   if( $species eq 'homo_sapiens' || $species eq 'human'){
     $assembly ||= $config->{human_assembly};

--- a/GO.pm
+++ b/GO.pm
@@ -49,14 +49,14 @@ limitations under the License.
  
    --plugin GO,${HOME}/go_terms
  
- The GNU zgrep and GNU sort commands must be installed in your path to create
- the custom GFF file. The tabix and bgzip utilities are also required: check
- https://github.com/samtools/htslib.git for installation instructions.
+ To create/use a custom GFF file, these programs must be installed in your path:
+   * The GNU zgrep and GNU sort commands to create the GFF file.
+   * The tabix and bgzip utilities to create and read the GFF file: check
+     https://github.com/samtools/htslib.git for installation instructions.
  
  Alternatively, for compatibility purposes, the plugin allows to use a remote
- connection to the Ensembl API by using "remote" as a parameter. This remote
- connection retrieves GO terms one by one at both the transcript and translation
- level:
+ connection to the Ensembl API by using "remote" as a parameter. This method
+ retrieves GO terms one by one at both the transcript and translation level:
 
    --plugin GO,remote
  

--- a/GO.pm
+++ b/GO.pm
@@ -297,7 +297,8 @@ sub _remote_run {
   
   # Get GO terms at transcript and translation levels
   my $entries = $tr->get_all_DBLinks('GO');
-  
+
+  # Format ID and description of GO terms (and ignore duplicates)
   my @go_terms = _uniq( map {$_->display_id.':'.$_->description} @$entries );
   my $string = join(",", @go_terms);
   $string =~ s/\s+/\_/g;

--- a/GO.pm
+++ b/GO.pm
@@ -33,7 +33,7 @@ limitations under the License.
 =head1 DESCRIPTION
 
  A VEP plugin that retrieves Gene Ontology terms associated with transcripts
- (GRCh38) or their translations (GRCh37). Requires database connection.
+ (e.g. GRCh38) or their translations (e.g. GRCh37).
  
 =cut
 
@@ -87,22 +87,22 @@ sub get_header_info {
 sub run {
   my ($self, $tva) = @_;
   
-  # Get GO terms from translation level if not available from transcript level
   my $tr = $tva->transcript;
-  my $entries = _get_GO_terms( $tr );
-  $entries = _get_GO_terms( $tr->translation ) unless defined(@$entries);
-  return {} unless defined(@$entries);
+  return {} unless defined($tr);
   
-  my $string = join(",", map {$_->display_id.':'.$_->description} @$entries);
+  # Get GO terms at transcript and translation levels
+  my $entries = $tr->get_all_DBLinks('GO');
+  
+  my @go_terms = _uniq( map {$_->display_id.':'.$_->description} @$entries );
+  my $string = join(",", @go_terms);
   $string =~ s/\s+/\_/g;
   
   return { GO => $string };
 }
 
-sub _get_GO_terms {
-  my $tr = shift;
-  return undef unless defined( $tr );
-  return $tr->get_all_DBEntries('GO');
+sub _uniq {
+  my %seen;
+  grep !$seen{$_}++, @_;
 }
 
 1;

--- a/GO.pm
+++ b/GO.pm
@@ -40,7 +40,7 @@ limitations under the License.
  species and assembly.
  
  For compatibility purposes, the plugin also allows to use a remote connection
- to the REST API by using "remote" as a parameter. This remote connection
+ to the Ensembl API by using "remote" as a parameter. This remote connection
  retrieves GO terms one by one at both the transcript and translation level.
  
 =cut

--- a/GO.pm
+++ b/GO.pm
@@ -261,7 +261,7 @@ sub _generate_gff {
     JOIN xref x ON ox.xref_id = x.xref_id
     JOIN seq_region sr ON transcript.seq_region_id = sr.seq_region_id
     JOIN external_db db ON x.external_db_id = db.external_db_id
-    WHERE db.db_name = "GO" AND db.dbprimary_acc LIKE "GO:%"
+    WHERE db.db_name = "GO" AND x.dbprimary_acc LIKE "GO:%"
     ORDER BY transcript.stable_id, # major assumption for the next steps
              x.display_label
   };


### PR DESCRIPTION
**Ticket [ENSVAR-4517](https://www.ebi.ac.uk/panda/jira/browse/ENSVAR-4517)** to resolve the following issues: #37 and #445 

Based on [Phenotypes.pm](https://github.com/Ensembl/VEP_plugins/blob/release/107/Phenotypes.pm), the GO.pm plugin was improved to:
1. Check if there is a Tabix-indexed GFF file based on species, assembly and database version in a given path. The path can be provided as an optional parameter (by default, the working directory is used).
2. If a specific GFF file is not available, perform a SQL query in the Ensembl core database to retrieve GO terms per transcript and write results as a Tabix-indexed GFF file.
3. Read the Tabix-indexed GFF file to retrieve the GO terms per transcript.

For compatibility purposes, the plugin accepts a `remote` parameter in order to use the Ensembl API just like in the previous version (based on [Conservation.pm](https://github.com/Ensembl/VEP_plugins/blob/release/107/Conservation.pm)), but with the following improvements:
- Supports GRCh38 assembly by using `get_all_DBLinks('GO')`
- Avoids returning duplicate GO terms
- Avoids returning blank strings `""`

## Testing

[GitHub repo](https://github.com/nuno-agostinho/VEP-GO-plugin-testing) used to test the plugin in the following conditions:
- Perl 5.14.4 and 5.26.2 (using plenv)
- JSON, TAB and VCF outputs
- Using database (with and without `remote` option) and cache
- Using GRCh37 and GRCh38 assemblies