### PR TITLE
feat: Add EVE Plugin

### DIFF
--- a/EVE.pm
+++ b/EVE.pm
@@ -40,6 +40,8 @@ package EVE;
 use strict;
 use warnings;
 
+use Bio::EnsEMBL::Variation::Utils::Sequence qw(get_matched_variant_alleles);
+
 use Bio::EnsEMBL::Variation::Utils::BaseVepTabixPlugin;
 use base qw(Bio::EnsEMBL::Variation::Utils::BaseVepTabixPlugin);
 
@@ -90,16 +92,24 @@ sub run {
   return {} unless(@data);
 
   foreach my $variant (@data) {
-    my @result;
-    
-    my $EVE_SCORE = $variant->{EVE_SCORE};
-    my $EVE_CLASS = $variant->{EVE_CLASS};
+    # TODO Better check
+    return {} unless($variant->{start});
 
-    return {
-      EVE_SCORE => $EVE_SCORE,
-      EVE_CLASS => $EVE_CLASS
-    };
+    my $matches = get_matched_variant_alleles(
+      {
+        ref    => $ref_allele,
+        alts   => [$alt_allele],
+        pos    => $vf->{start},
+        strand => $vf->strand
+      },
+      {
+       ref  => $variant->{ref},
+       alts => [$variant->{alt}],
+       pos  => $variant->{start},
+      }
+    );
 
+    return $variant->{result} if (@$matches);
   }
 
 }

--- a/EVE.pm
+++ b/EVE.pm
@@ -44,18 +44,6 @@ use Bio::EnsEMBL::Variation::Utils::BaseVepTabixPlugin;
 use base qw(Bio::EnsEMBL::Variation::Utils::BaseVepTabixPlugin);
 
 sub new {
-
-}
-
-sub get_header_info {
-  my $self = shift;
-  return {
-    EVE_SCORE => 'Score from EVE model',
-    EVE_CLASS   => 'Classification (Benign, Uncertain, or Pathogenic) when setting 70% as uncertain'
-  }
-}
-
-sub run {
   my $class = shift;
 
   my $self = $class->SUPER::new(@_);
@@ -68,6 +56,18 @@ sub run {
   $self->add_file($param_hash->{file});
 
   return $self;
+}
+
+sub get_header_info {
+  my $self = shift;
+  return {
+    EVE_SCORE => 'Score from EVE model',
+    EVE_CLASS   => 'Classification (Benign, Uncertain, or Pathogenic) when setting 70% as uncertain'
+  }
+}
+
+sub run {
+
 }
 
 sub parse_data {

--- a/EVE.pm
+++ b/EVE.pm
@@ -28,7 +28,8 @@ limitations under the License.
 =head1 SYNOPSIS
 
  cp EVE.pm ${HOME}/.vep/Plugins
- ./vep -i variations.vcf --plugin EVE,file=/path/to/eve/data.vcf.gz
+ ./vep -i variations.vcf --plugin EVE,file=/path/to/eve/data.vcf.gz # By default, Class75 is used.
+ ./vep -i variations.vcf --plugin EVE,file=/path/to/eve/data.vcf.gz,class_number=60
 
 =head1 DESCRIPTION
 
@@ -101,9 +102,20 @@ sub new {
 
   my $param_hash = $self->params_to_hash();
 
-  die "\nERROR: No EVE file specified\n" unless defined($param_hash->{file});
+  die "\nERROR: No EVE file specified\nTry using 'file=<path-to>/eve_file.vcf.gz'\n" unless defined($param_hash->{file});
 
   $self->add_file($param_hash->{file});
+
+  my @valid_class_numbers = (10, 20, 25, 30, 40, 50, 60, 70, 75, 80, 90);
+
+  if (defined($param_hash->{class_number})) {
+
+    die "\nERROR: This class_number: '$param_hash->{class_number}' does not exists.\nTry any of this numbers: " . join(', ', @valid_class_numbers)
+    unless ($param_hash->{class_number} ~~ @valid_class_numbers);
+    $self->{class_number} = $param_hash->{class_number};
+  } else {
+    $self->{class_number} = 75;
+  }
 
   return $self;
 }
@@ -173,7 +185,8 @@ sub parse_data {
 
   # Parsing INFO field
   my ($EVE_SCORE) = $info =~ /EVE=(.*?);/;
-  my ($EVE_CLASS) = $info =~ /Class75=(.*?);/;
+  my $class_number = $self->{class_number};
+  my ($EVE_CLASS) = $info =~ /Class$class_number=(.*?);/;
 
   return {
     ref => $ref,

--- a/EVE.pm
+++ b/EVE.pm
@@ -93,6 +93,9 @@ sub new {
 
   my $param_hash = $self->params_to_hash();
 
+  my @params = @{$self->params};
+  die "\nERROR: No EVE file specified\n" unless @params > 0;
+
   $self->add_file($param_hash->{file});
 
   return $self;

--- a/EVE.pm
+++ b/EVE.pm
@@ -45,7 +45,7 @@ limitations under the License.
 
 ### BEGIN
 
-# Data link: https://evemodel.org/api/proteins/bulk/download/
+# EVE input file can be downloaded from https://evemodel.org/api/proteins/bulk/download/ 
 # Input: VCF files by protein (vcf_files_missense_mutations inside zip folder)
 # Output: Compressed Merged VCF file (vcf.gz) + index file (.tbi)
 

--- a/EVE.pm
+++ b/EVE.pm
@@ -34,6 +34,8 @@ limitations under the License.
 
  This is a plugin for the Ensembl Variant Effect Predictor (VEP) that
  adds information from EVE (evolutionary model of variant effect).
+ In this plugin, only single nucleotide variants (SNVs) are analyzed,
+ multiple nucleotides variants (MNVs) are not included.
  It is only available for GRCh38.
 
  Please cite EVE publication alongside the VEP if you use this resource:

--- a/EVE.pm
+++ b/EVE.pm
@@ -32,7 +32,45 @@ limitations under the License.
 
 =head1 DESCRIPTION
 
+ This is a plugin for the Ensembl Variant Effect Predictor (VEP) that
+ adds information from EVE (evolutionary model of variant effect).
+ It is only available for GRCh38.
 
+ Please cite EVE publication alongside the VEP if you use this resource:
+ https://www.nature.com/articles/s41586-021-04043-8
+
+###################################################
+# Bash script to merge all VCFs from EVE dataset. #
+###################################################
+
+### BEGIN
+
+# Data link: https://evemodel.org/api/proteins/bulk/download/
+# Input: VCF files by protein (vcf_files_missense_mutations inside zip folder)
+# Output: Compressed Merged VCF file (vcf.gz) + index file (.tbi)
+
+DATA_FOLDER='/<PATH-TO>/vcf_files_missense_mutations' # Fill this line
+OUTPUT_FOLDER='/<PATH-TO>/eve_plugin' # Fill this line
+OUTPUT_NAME='eve_merged.vcf' # Default output name
+
+# Get header from first VCF
+cat `ls ${DATA_FOLDER}/*vcf | head -n1` > header
+
+# Get variants from all VCFs and add to a single-file
+ls ${DATA_FOLDER}/*vcf | while read VCF; do grep -v '^#' ${VCF} >> variants; done
+
+# Merge Header + Variants in a single file
+cat header variants | \
+awk '$1 ~ /^#/ {print $0;next} {print $0 | "sort -k1,1V -k2,2n"}' > ${OUTPUT_FOLDER}/${OUTPUT_NAME};
+
+# Remove temporary files
+rm header variants
+
+# Compress and index
+bgzip ${OUTPUT_FOLDER}/${OUTPUT_NAME};
+tabix ${OUTPUT_FOLDER}/${OUTPUT_NAME}.gz;
+
+### END
 
 =cut
 package EVE;

--- a/EVE.pm
+++ b/EVE.pm
@@ -56,7 +56,18 @@ sub get_header_info {
 }
 
 sub run {
+  my $class = shift;
 
+  my $self = $class->SUPER::new(@_);
+
+  $self->expand_left(0);
+  $self->expand_right(0);
+
+  my $param_hash = $self->params_to_hash();
+
+  $self->add_file($param_hash->{file});
+
+  return $self;
 }
 
 sub parse_data {

--- a/EVE.pm
+++ b/EVE.pm
@@ -93,8 +93,7 @@ sub new {
 
   my $param_hash = $self->params_to_hash();
 
-  my @params = @{$self->params};
-  die "\nERROR: No EVE file specified\n" unless @params > 0;
+  die "\nERROR: No EVE file specified\n" unless defined($param_hash->{file});
 
   $self->add_file($param_hash->{file});
 

--- a/EVE.pm
+++ b/EVE.pm
@@ -113,6 +113,8 @@ sub run {
     return $variant->{result} if (@$matches);
   }
 
+  return {};
+
 }
 
 sub parse_data {

--- a/EVE.pm
+++ b/EVE.pm
@@ -96,7 +96,7 @@ sub run {
     my $EVE_CLASS = $variant->{EVE_CLASS};
 
     return {
-      EVE_SCORE   => $EVE_SCORE,
+      EVE_SCORE => $EVE_SCORE,
       EVE_CLASS => $EVE_CLASS
     };
 
@@ -125,11 +125,13 @@ sub parse_data {
   my ($EVE_SCORE) = $info =~ /EVE=(.*?);/;
   my ($EVE_CLASS) = $info =~ /Class70=(.*?);/;
 
+  my %new_snp = get_snp_from_codon($ref, $alt, $pos);
+
   return {
     chrom => $chrom,
-    ref => $ref,
-    alt => $alt,
-    start => $pos,
+    ref => $new_snp{ref},
+    alt => $new_snp{alt},
+    start => $new_snp{pos},
     EVE_SCORE   => $EVE_SCORE,
     EVE_CLASS   => $EVE_CLASS
   };
@@ -141,6 +143,25 @@ sub get_start {
 
 sub get_end {
   return $_[1]->{end};
+}
+
+# Additional function
+sub get_snp_from_codon {
+  my ($ref, $alt, $pos) = @_;
+
+  my $mask = $ref ^ $alt;
+  while ($mask =~ /[^\0]/g) {
+      $ref = substr($ref,$-[0],1);
+      $alt = substr($alt,$-[0],1);
+      $pos += $-[0];
+  }
+
+  return (
+    ref => $ref,
+    alt => $alt,
+    pos => $pos
+  )
+
 }
 
 1;

--- a/EVE.pm
+++ b/EVE.pm
@@ -95,6 +95,10 @@ sub new {
   $self->expand_left(0);
   $self->expand_right(0);
 
+  my $assembly = $self->{config}->{assembly};
+
+  die "\nAssembly is not GRCh38, EVE only works with GRCh38. \n" if ($assembly ne "GRCh38");
+
   my $param_hash = $self->params_to_hash();
 
   die "\nERROR: No EVE file specified\n" unless defined($param_hash->{file});

--- a/EVE.pm
+++ b/EVE.pm
@@ -116,7 +116,7 @@ sub get_header_info {
   my $self = shift;
   return {
     EVE_SCORE => 'Score from EVE model',
-    EVE_CLASS   => 'Classification (Benign, Uncertain, or Pathogenic) when setting 70% as uncertain'
+    EVE_CLASS   => 'Classification (Benign, Uncertain, or Pathogenic) when setting 75% as uncertain'
   }
 }
 
@@ -178,7 +178,7 @@ sub parse_data {
 
   # Parsing INFO field
   my ($EVE_SCORE) = $info =~ /EVE=(.*?);/;
-  my ($EVE_CLASS) = $info =~ /Class70=(.*?);/;
+  my ($EVE_CLASS) = $info =~ /Class75=(.*?);/;
 
   my %new_snp = _get_snp_from_codon($ref, $alt, $pos);
 

--- a/EVE.pm
+++ b/EVE.pm
@@ -93,8 +93,8 @@ sub run {
   return {} unless(@data);
 
   foreach my $variant (@data) {
-    # TODO Better check
-    return {} unless($variant->{start});
+    # This check should disappear with multiple snps codons
+    return {} unless($variant->{start} and $variant->{ref} and $variant->{alt});
 
     my $matches = get_matched_variant_alleles(
       {
@@ -123,6 +123,7 @@ sub parse_data {
 
   my $allele_difference = ($ref ^ $alt) =~ tr/\0//c;
 
+  # TODO Prepare multiple SNPs codons part
   if ($allele_difference > 1){
     return {};
   }

--- a/EVE.pm
+++ b/EVE.pm
@@ -80,7 +80,7 @@ sub run {
   my $alt_allele = $tva->variation_feature_seq;
   my $ref_allele = $vf->ref_allele_string;
 
-  return {} unless $allele =~ /^[ACGT-]+$/;
+  return {} unless $alt_allele =~ /^[ACGT-]+$/;
 
   my @data = @{
     $self->get_data(

--- a/EVE.pm
+++ b/EVE.pm
@@ -124,6 +124,8 @@ sub run {
   my ($self, $tva) = @_;
   my $vf = $tva->variation_feature;
 
+  return {} unless grep {$_->SO_term eq 'missense_variant'} @{$tva->get_all_OverlapConsequences};
+
   # get allele
   my $alt_allele = $tva->variation_feature_seq;
   my $ref_allele = $vf->ref_allele_string;

--- a/EVE.pm
+++ b/EVE.pm
@@ -89,20 +89,16 @@ sub run {
 
   return {} unless(@data);
 
-  my %hash;
-  my @final_result;
-
   foreach my $variant (@data) {
     my @result;
     
     my $EVE_SCORE = $variant->{EVE_SCORE};
+    my $EVE_CLASS = $variant->{EVE_CLASS};
 
-    push @result, $EVE_SCORE;
-    push @final_result, join(':', @result);
-
-    $hash{"EVE"} = [@final_result];
-
-    return \%hash;
+    return {
+      EVE_SCORE   => $EVE_SCORE,
+      EVE_CLASS => $EVE_CLASS
+    };
 
   }
 
@@ -118,16 +114,24 @@ sub parse_data {
 
   # Parsing VCF fields
   my ($chrom, $pos, $id, $ref, $alt, $qual, $filter, $info) = split /\t/, $line; 
-  
+
+  my $allele_difference = ($ref ^ $alt) =~ tr/\0//c;
+
+  if ($allele_difference > 1){
+    return {};
+  }
+
   # Parsing INFO field
-  my ($EVE_SCORE) = split /;/, $info;
+  my ($EVE_SCORE) = $info =~ /EVE=(.*?);/;
+  my ($EVE_CLASS) = $info =~ /Class70=(.*?);/;
 
   return {
     chrom => $chrom,
     ref => $ref,
     alt => $alt,
     start => $pos,
-    EVE_SCORE   => $EVE_SCORE
+    EVE_SCORE   => $EVE_SCORE,
+    EVE_CLASS   => $EVE_CLASS
   };
 }
 

--- a/EVE.pm
+++ b/EVE.pm
@@ -131,8 +131,6 @@ sub run {
   return {} unless(@data);
 
   foreach my $variant (@data) {
-    # This check should disappear with multiple snps codons
-    return {} unless($variant->{start} and $variant->{ref} and $variant->{alt});
 
     my $matches = get_matched_variant_alleles(
       {

--- a/EVE.pm
+++ b/EVE.pm
@@ -109,7 +109,7 @@ sub new {
 }
 
 sub feature_types {
-  return ['Feature'];
+  return ['Transcript'];
 }
 
 sub get_header_info {

--- a/EVE.pm
+++ b/EVE.pm
@@ -28,7 +28,7 @@ limitations under the License.
 =head1 SYNOPSIS
 
  cp EVE.pm ${HOME}/.vep/Plugins
- ./vep -i variations.vcf --plugin EVE,file=/path/to/disgenet/data.tsv.gz
+ ./vep -i variations.vcf --plugin EVE,file=/path/to/eve/data.vcf.gz
 
 =head1 DESCRIPTION
 

--- a/EVE.pm
+++ b/EVE.pm
@@ -1,0 +1,74 @@
+=head1 LICENSE
+
+Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
+Copyright [2016-2022] EMBL-European Bioinformatics Institute
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=head1 CONTACT
+
+ Ensembl <http://www.ensembl.org/info/about/contact/index.html>
+
+=cut
+
+=head1 NAME
+
+ EVE
+
+=head1 SYNOPSIS
+
+ cp EVE.pm ${HOME}/.vep/Plugins
+ ./vep -i variations.vcf --plugin EVE,file=/path/to/disgenet/data.tsv.gz
+
+=head1 DESCRIPTION
+
+
+
+=cut
+package EVE;
+
+use strict;
+use warnings;
+
+use Bio::EnsEMBL::Variation::Utils::BaseVepTabixPlugin;
+use base qw(Bio::EnsEMBL::Variation::Utils::BaseVepTabixPlugin);
+
+sub new {
+
+}
+
+sub get_header_info {
+  my $self = shift;
+  return {
+    EVE_SCORE => 'Score from EVE model',
+    EVE_CLASS   => 'Classification (Benign, Uncertain, or Pathogenic) when setting 70% as uncertain'
+  }
+}
+
+sub run {
+
+}
+
+sub parse_data {
+
+}
+
+sub get_start {
+  return $_[1]->{start};
+}
+
+sub get_end {
+  return $_[1]->{end};
+}
+
+1;

--- a/EVE.pm
+++ b/EVE.pm
@@ -34,8 +34,8 @@ limitations under the License.
 
  This is a plugin for the Ensembl Variant Effect Predictor (VEP) that
  adds information from EVE (evolutionary model of variant effect).
- In this plugin, only single nucleotide variants (SNVs) are analyzed,
- multiple nucleotides variants (MNVs) are not included.
+ This plugin only report EVE scores for input variants
+ and does not merge input lines to report on adjacent variants.
  It is only available for GRCh38.
 
  Please cite EVE publication alongside the VEP if you use this resource:

--- a/EVE.pm
+++ b/EVE.pm
@@ -127,8 +127,8 @@ sub feature_types {
 sub get_header_info {
   my $self = shift;
   return {
-    EVE_SCORE => 'Score from EVE model',
-    EVE_CLASS   => 'Classification (Benign, Uncertain, or Pathogenic) when setting class_number (default 75%) as uncertain'
+    EVE_SCORE => "Score from EVE model",
+    EVE_CLASS   => "Classification (Benign, Uncertain, or Pathogenic) when setting $self->{class_number}% as uncertain"
   }
 }
 
@@ -186,7 +186,7 @@ sub parse_data {
   # Parsing INFO field
   my ($EVE_SCORE) = $info =~ /EVE=(.*?);/;
   my $class_number = $self->{class_number};
-  my ($EVE_CLASS) = $info =~ /Class$class_number=(.*?);/;
+  my ($EVE_CLASS) = $info =~ /Class$class_number=(.*?)([;]|$)/;
 
   return {
     ref => $ref,

--- a/EVE.pm
+++ b/EVE.pm
@@ -59,7 +59,7 @@ sub new {
 }
 
 sub feature_types {
-  return ['Feature','Intergenic'];
+  return ['Feature'];
 }
 
 sub get_header_info {

--- a/EVE.pm
+++ b/EVE.pm
@@ -171,23 +171,14 @@ sub parse_data {
   # Parsing VCF fields
   my ($chrom, $pos, $id, $ref, $alt, $qual, $filter, $info) = split /\t/, $line; 
 
-  my $allele_difference = ($ref ^ $alt) =~ tr/\0//c;
-
-  # TODO Prepare multiple SNPs codons part
-  if ($allele_difference > 1){
-    return {};
-  }
-
   # Parsing INFO field
   my ($EVE_SCORE) = $info =~ /EVE=(.*?);/;
   my ($EVE_CLASS) = $info =~ /Class75=(.*?);/;
 
-  my %new_snp = _get_snp_from_codon($ref, $alt, $pos);
-
   return {
-    ref => $new_snp{ref},
-    alt => $new_snp{alt},
-    start => $new_snp{pos},
+    ref => $ref,
+    alt => $alt,
+    start => $pos,
     result => {
       EVE_SCORE   => $EVE_SCORE,
       EVE_CLASS   => $EVE_CLASS
@@ -201,25 +192,6 @@ sub get_start {
 
 sub get_end {
   return $_[1]->{end};
-}
-
-# Additional function
-sub _get_snp_from_codon {
-  my ($ref, $alt, $pos) = @_;
-
-  my $mask = $ref ^ $alt;
-  while ($mask =~ /[^\0]/g) {
-      $ref = substr($ref,$-[0],1);
-      $alt = substr($alt,$-[0],1);
-      $pos += $-[0];
-  }
-
-  return (
-    ref => $ref,
-    alt => $alt,
-    pos => $pos
-  )
-
 }
 
 1;

--- a/EVE.pm
+++ b/EVE.pm
@@ -128,7 +128,7 @@ sub get_header_info {
   my $self = shift;
   return {
     EVE_SCORE => 'Score from EVE model',
-    EVE_CLASS   => 'Classification (Benign, Uncertain, or Pathogenic) when setting 75% as uncertain'
+    EVE_CLASS   => 'Classification (Benign, Uncertain, or Pathogenic) when setting class_number (default 75%) as uncertain'
   }
 }
 

--- a/EVE.pm
+++ b/EVE.pm
@@ -68,6 +68,8 @@ rm header variants
 
 # Compress and index
 bgzip ${OUTPUT_FOLDER}/${OUTPUT_NAME};
+
+# If not installed, use: sudo apt install tabix
 tabix ${OUTPUT_FOLDER}/${OUTPUT_NAME}.gz;
 
 ### END

--- a/plugin_config.txt
+++ b/plugin_config.txt
@@ -1003,7 +1003,8 @@ my $VEP_PLUGIN_CONFIG = {
     # Requires tabix-indexed data file as params
     # No other parameters so no form required
     # data file currently only available for GRCh38
-    # EVE is only avaiable for SNPs, MNVs are not mapped.
+    # We only report EVE scores for input variants and
+    # don't consider adjacent variants.
     {
       "key" => "EVE",
       "label" => "EVE",

--- a/plugin_config.txt
+++ b/plugin_config.txt
@@ -998,6 +998,29 @@ my $VEP_PLUGIN_CONFIG = {
       ]
     },
 
+    # EVE
+    # https://github.com/ensembl-variation/VEP_plugins/blob/master/EVE.pm
+    # Requires tabix-indexed data file as params
+    # No other parameters so no form required
+    # data file currently only available for GRCh38
+    # EVE is only avaiable for SNPs, MNVs are not mapped.
+    {
+      "key" => "EVE",
+      "label" => "EVE",
+      "available" => 0,
+      "enabled" => 0,
+      "section" => "Pathogenicity predictions",
+      "helptip" => "EVE (evolutionary model of variant effect) is a computational method for the classification of human genetic variants trained solely on evolutionary sequences.",
+      "plugin_url" => "https://raw.githubusercontent.com/Ensembl/VEP_plugins/release/107/EVE.pm",
+      "requires_data" => 1,
+      "species" => [
+        "homo_sapiens"
+      ],
+      "params" => [
+        #"/path/to/eve_merged.vcf.gz"
+      ]
+    },
+
     ## SPLICING PREDICTIONS
     #######################
 


### PR DESCRIPTION
JIRA Ticket: [here](https://www.ebi.ac.uk/panda/jira/browse/ENSVAR-4502)
Confluence: [here](https://www.ebi.ac.uk/seqdb/confluence/pages/viewpage.action?spaceKey=EV&title=EVE+Plugin)

## Description

We are going to add [EVE data](https://evemodel.org/) as an easy-to-run plugin inside VEP. This data should add potential information to tag clinical relevant SNPs.  For more information, look at [publication](https://www.nature.com/articles/s41586-021-04043-8).

## Test

Just add --plugin flag with EVE + file, example:
`--plugin EVE,file=<PATH-TO>/eve_merged.vcf.gz`

Output should have EVE_SCORE + EVE_CLASS in output VCF.
