### PR TITLE
refactor: parse data with header + add specified file check 

### DIFF
--- a/CADD.pm
+++ b/CADD.pm
@@ -88,7 +88,7 @@ sub new {
   # Check files in arguments
   my @params = @{$self->params};
 
-  die "\nERROR: No CADD files specified\nTip: Add a file after command, example:\nvep ... --custom CADD,/FULL_PATH_TO_CADD_FILE/whole_genome_SNVs.tsv.gz\n" unless @params > 0;
+  die "\nERROR: No CADD files specified\nTip: Add a file after command, example:\nvep ... --plugin CADD,/FULL_PATH_TO_CADD_FILE/whole_genome_SNVs.tsv.gz\n" unless @params > 0;
   $self->add_file($_) for @params;
 
   $self->{header} = ();

--- a/CADD.pm
+++ b/CADD.pm
@@ -100,9 +100,9 @@ sub new {
 
     my @lines = <IN>;
 
-    my @matches =  grep { /$assembly/ } @lines if (defined($assembly));
+    my @assembly_header_matches =  grep { /$assembly/ } @lines if (defined($assembly));
 
-    if (!@matches && $assembly) {
+    if (!@assembly_header_matches && $assembly) {
       die "\nERROR: Assembly is " . $assembly .
           " but CADD file does not contain " .
           $assembly . " in header.\n";

--- a/CADD.pm
+++ b/CADD.pm
@@ -178,6 +178,13 @@ sub parse_data {
   my $ref = $data{"Ref"};
   my $alt = $data{"Alt"};
 
+  # Conditional result
+  my %result = ();
+  foreach (keys %INCLUDE_COLUMNS){
+    next unless (exists($data{$_}));
+    $result{$INCLUDE_COLUMNS{$_}{"name"}} = $data{$_};
+  }
+
   # do VCF-like coord adjustment for mismatched subs
   my $end = ($s + length($ref)) - 1;
   if(length($alt) != length($ref)) {
@@ -197,10 +204,7 @@ sub parse_data {
     alt => $alt,
     start => $s,
     end => $end,
-    result => {
-      CADD_RAW   => $data{"RawScore"},
-      CADD_PHRED => $data{"PHRED"}
-    }
+    result => \%result
   };
 }
 

--- a/CADD.pm
+++ b/CADD.pm
@@ -139,11 +139,20 @@ sub run {
 }
 
 sub parse_data {
-  my ($self, $line) = @_;
-  my ($c, $s, $ref, $alt, $raw, $phred) = split /\t/, $line;
+  my ($self, $line, $file) = @_;
+
+  my @headers = split /\t/, $self->{$file};
+  my @values = split /\t/, $line;
+
+  my %data = map {$headers[$_] => $values[$_]} (0..(@headers - 1));
+
+  my $c = $data{"#Chrom"};
+  my $s = $data{"Pos"};
+  my $ref = $data{"Ref"};
+  my $alt = $data{"Alt"};
 
   # do VCF-like coord adjustment for mismatched subs
-  my $e = ($s + length($ref)) - 1;
+  my $end = ($s + length($ref)) - 1;
   if(length($alt) != length($ref)) {
     my $first_ref = substr($ref, 0, 1);
     my $first_alt = substr($alt, 0, 1);
@@ -155,14 +164,15 @@ sub parse_data {
       $alt ||= '-';
     }
   }
+
   return {
     ref => $ref,
     alt => $alt,
     start => $s,
-    end => $e,
+    end => $end,
     result => {
-      CADD_RAW   => $raw,
-      CADD_PHRED => $phred
+      CADD_RAW   => $data{"RawScore"},
+      CADD_PHRED => $data{"PHRED"}
     }
   };
 }

--- a/CADD.pm
+++ b/CADD.pm
@@ -60,6 +60,18 @@ use Bio::EnsEMBL::Variation::Utils::BaseVepTabixPlugin;
 
 use base qw(Bio::EnsEMBL::Variation::Utils::BaseVepTabixPlugin);
 
+# List here all columns in headers that should be included
+my %INCLUDE_COLUMNS = (
+    "PHRED" => {
+      "name" => "CADD_PHRED",
+      "description" => 'PHRED-like scaled CADD score'
+    },
+    "RawScore" => {
+      "name" => "CADD_RAW",
+      "description" => 'Raw CADD score'
+    }
+);
+
 sub new {
   my $class = shift;
   

--- a/CADD.pm
+++ b/CADD.pm
@@ -77,6 +77,9 @@ sub new {
   
   my $self = $class->SUPER::new(@_);
 
+  # Test if tabix exists
+  die "\nERROR: tabix does not seem to be in your path\n" unless `which tabix 2>&1` =~ /tabix$/;
+
   $self->expand_left(0);
   $self->expand_right(0);
 

--- a/CADD.pm
+++ b/CADD.pm
@@ -107,11 +107,15 @@ sub new {
     # Make sure it has a known prefix in header
     die "'#Chrom' was not found on header" unless $self->{$file};
 
+    my $file_check = 0;
     # Conditional header
     for (split /\t/, $self->{$file}){
       next unless (exists($INCLUDE_COLUMNS{$_}));
+      $file_check = 1;
       $self->{header}{$INCLUDE_COLUMNS{$_}{"name"}} = $INCLUDE_COLUMNS{$_}{"description"};
     }
+
+    die "\nERROR: $file does not have a known column to be included" unless $file_check;
 
   }
 

--- a/CADD.pm
+++ b/CADD.pm
@@ -54,7 +54,6 @@ package CADD;
 use strict;
 use warnings;
 
-use Bio::EnsEMBL::Utils::Sequence qw(reverse_comp);
 use Bio::EnsEMBL::Variation::Utils::Sequence qw(get_matched_variant_alleles);
 
 use Bio::EnsEMBL::Variation::Utils::BaseVepTabixPlugin;

--- a/CADD.pm
+++ b/CADD.pm
@@ -70,6 +70,28 @@ sub new {
 
   $self->get_user_params();
 
+  # Check files in arguments
+  my @params = @{$self->params};
+
+  die "\nERROR: No CADD files specified\nTip: Add a file after command, example:\nvep ... --custom CADD,/FULL_PATH_TO_CADD_FILE/whole_genome_SNVs.tsv.gz\n" unless @params > 0;
+  $self->add_file($_) for @params;
+
+  foreach my $file (@params) {
+    open IN, "tabix -f -h ".$file." 1:1-1 |";
+
+    my @lines = <IN>;
+
+    while (my $line = shift @lines) {
+      next if (rindex $line, "#Chrom", 0);
+      $self->{$file} = $line;
+    }
+
+    die "'#Chrom' was not found on header" unless $self->{$file};
+
+  }
+
+  close IN;
+
   return $self;
 }
 

--- a/CADD.pm
+++ b/CADD.pm
@@ -91,6 +91,8 @@ sub new {
   die "\nERROR: No CADD files specified\nTip: Add a file after command, example:\nvep ... --plugin CADD,/FULL_PATH_TO_CADD_FILE/whole_genome_SNVs.tsv.gz\n" unless @params > 0;
   $self->add_file($_) for @params;
 
+  my $assembly = $self->{config}->{assembly};
+
   $self->{header} = ();
 
   foreach my $file (@params) {
@@ -98,7 +100,16 @@ sub new {
 
     my @lines = <IN>;
 
+    my @matches =  grep { /$assembly/ } @lines if (defined($assembly));
+
+    if (!@matches && $assembly) {
+      die "\nERROR: Assembly is " . $assembly .
+          " but CADD file does not contain " .
+          $assembly . " in header.\n";
+    }
+
     while (my $line = shift @lines) {
+
       next if (rindex $line, "#Chrom", 0);
       chomp $line;
       $self->{$file} = $line;

--- a/plugin_config.txt
+++ b/plugin_config.txt
@@ -690,7 +690,6 @@ my $VEP_PLUGIN_CONFIG = {
     # https://github.com/ensembl-variation/VEP_plugins/blob/master/CADD.pm
     # Requires tabix-indexed data file as first param
     # No other parameters so no form required
-    # data file currently only available for GRCh37
     {
       "key" => "CADD",
       "label" => "CADD",


### PR DESCRIPTION
## Description

CADD plugin subroutine `parse_data()` uses a fixed header structures (6 columns). Therefore, it's not possible for similar CADD files to be used as input and possibly can introduce a few errors. Thereby, in this pull request, it was introduced a parsing directly on header names which should maintain old compatibility + introduce new possibilities.

## Test

1) Run CADD with a 6-column example with master + this branch and make sure output is the same.
2) Run CADD with different column structures (less and more than 6-column).
3) Run CADD with no columns that should be expected (no PHRED or RawScore).
3) Check if all new "die"s works properly and cover properly CADD.

## Dependecies (approve before this PR)

* Ensembl-variation: [here](https://github.com/Ensembl/ensembl-variation/pull/788)