### PR TITLE
feat: Include filename in dbNSFP header

### DIFF
--- a/dbNSFP.pm
+++ b/dbNSFP.pm
@@ -138,6 +138,7 @@ package dbNSFP;
 
 use strict;
 use warnings;
+use File::Basename qw(basename);
 
 use Bio::EnsEMBL::Utils::Sequence qw(reverse_comp);
 
@@ -170,6 +171,8 @@ sub new {
   
   # get dbNSFP file
   my $file = $self->params->[$index];
+  my $basename = basename($file, ".gz");
+
   my $version;
   if ($file =~ /2\.9/) {
     $version = '2.9';
@@ -183,6 +186,7 @@ sub new {
     die "ERROR: Could not retrieve dbNSFP version from filename $file\n";
   }
   $self->{dbNSFP_version} = $version;
+  $self->{basename} = $basename;
 
   $self->add_file($file);
   
@@ -297,7 +301,7 @@ sub get_header_info {
               m/^\d+\s+(.+?)\:\s+(.+)/;
               $col = $1;
 
-              $rm_descs{$col} = '(from dbNSFP) '.$2 if $col && $2;
+              $rm_descs{$col} = "(from $self->{basename}) ".$2 if $col && $2;
             }
             elsif($reading && /\w/) {
               s/^\s+//;


### PR DESCRIPTION
## Description

This PR is meant to add version used in dbNSFP Plugin header as mentioned in https://github.com/Ensembl/VEP_plugins/issues/474. Since dbNSFP version is only based on filename, I added full filename without `.gz` suffix to indicate which version was used in plugin.

## Test

1. Run VEP with `--plugin dbNSFP,/path-to/dbNSFP_file.gz,CADD_phred`

For example:

`--plugin dbNSFP,/many/directories/to/file/dbNSFP/4.3a/dbNSFP4.3a_grch38.gz,CADD_phred` should have
`##CADD_phred=(from dbNSFP4.3a_grch38)` as a header