### PR TITLE
Support LRGs in LOVD plugin

### DIFF
--- a/LOVD.pm
+++ b/LOVD.pm
@@ -92,7 +92,7 @@ sub run {
     if ( $feature->coord_system_name() eq "lrg" ) {
         $feature = $vf->transform('chromosome');
         unless ( $feature ) {
-            warn "Region $vf->{chr}:$vf->{start}_$vf->{end} not defined in" .
+            warn "Region $vf->{chr}:$vf->{start}_$vf->{end} not defined in " .
                  "chromosome coordinate system\n";
             return {};
         }

--- a/LOVD.pm
+++ b/LOVD.pm
@@ -87,10 +87,20 @@ sub run {
     my $ua = LWP::UserAgent->new;
     $ua->env_proxy;
 
-    my $chr = $vf->{chr};
+    my $feature = $vf;
+    # Convert LRG to chromosome system
+    if ( $feature->coord_system_name() eq "lrg" ) {
+        $feature = $vf->transform('chromosome');
+        unless ( $feature ) {
+            warn "Region $vf->{chr}:$vf->{start}_$vf->{end} not defined in" .
+                 "chromosome coordinate system\n";
+            return {};
+        }
+    }
+    my $chr = $feature->slice->seq_region_name();
     $chr =~ s/^chr//;
     
-    my $locus = sprintf('chr%s:%s_%s', $chr, $vf->{start}, $vf->{end});
+    my $locus = sprintf 'chr%s:%s_%s', $chr, $feature->{start}, $feature->{end};
     
     my $data;
     


### PR DESCRIPTION
[Ticket ENSVAR-4344](https://www.ebi.ac.uk/panda/jira/browse/ENSVAR-4344) to solve the last issue reported in Ensembl/ensembl-vep#1041

## Motivation

When running LRG variants with the LOVD plugin, we get the following warnings for each LRG variant:

```
Use of uninitialized value $gene in join or string at /hps/software/users/ensembl/repositories/nuno/VEP_plugins/LOVD.pm line 114, <$__ANONIO__> line 3.
Use of uninitialized value $acc in join or string at /hps/software/users/ensembl/repositories/nuno/VEP_plugins/LOVD.pm line 114, <$__ANONIO__> line 3.
Use of uninitialized value $dna in join or string at /hps/software/users/ensembl/repositories/nuno/VEP_plugins/LOVD.pm line 114, <$__ANONIO__> line 3.
```

## Explanation

LOVD plugin queries the REST API of LOVD using the slice name, start and end for each variant, forming an URL like so: http://www.lovd.nl/search.php?build=hg38&position=chr1:1212606_1212605

With the VEP `--lrg` argument enabled, some variants return their LRG coordinates instead, resulting in the following unsupported URL: http://www.lovd.nl/search.php?build=hg38&position=chrLRG_1319:7034_7033.

When using URLs formed by LRG variants, the LOVD API response `The position argument was empty or malformed.` is parsed using `my ($build, $pos, $gene, $acc, $dna, $url) = split /\t/;`. Therefore, the variables `$gene`, `$acc` and `$url` are not defined and thus the warning that they are `uninitialized values`.

Given that the LOVD REST API seems not to support LRG coordinates (the [LOVD documentation](https://www.lovd.nl/3.0/docs/LOVD_manual_3.0.pdf) is not explicit about this), this PR converts LRGs to chromosome coordinates, thus allowing to create an URL supported by the LOVD API.

## Testing

**Sample input (contains LRG variants):** [vep_INS_1_1000.txt](https://github.com/Ensembl/VEP_plugins/files/8410820/vep_INS_1_1000.txt)

**Run VEP using the LOVD plugin with LRG enabled and disabled (the output should be the same in both cases):**
```bash
perl $HOME/ensembl-vep/vep \
     --verbose \
     --database \
     --dir_cache $cachedir \
     --cache_version 104 \
     --assembly GRCh38 \
     --force_overwrite \
     --input_file vep_INS_1_1000.txt \
     --output_file output_ins_1_1000.vep \
     --species homo_sapiens \
     --plugin LOVD \
     --db_version 104 \
     --lrg
```