### PR TITLE
fix: update maxentscan web

### DIFF
--- a/MaxEntScan.pm
+++ b/MaxEntScan.pm
@@ -34,12 +34,12 @@ limitations under the License.
 =head1 DESCRIPTION
 
  This is a plugin for the Ensembl Variant Effect Predictor (VEP) that
- runs MaxEntScan (http://genes.mit.edu/burgelab/maxent/Xmaxentscan_scoreseq.html)
+ runs MaxEntScan (http://hollywood.mit.edu/burgelab/maxent/Xmaxentscan_scoreseq.html)
  to get splice site predictions.
 
  The plugin copies most of the code verbatim from the score5.pl and score3.pl
  scripts provided in the MaxEntScan download. To run the plugin you must get and
- unpack the archive from http://genes.mit.edu/burgelab/maxent/download/; the path
+ unpack the archive from http://hollywood.mit.edu/burgelab/maxent/download/; the path
  to this unpacked directory is then the param you pass to the --plugin flag.
 
  The plugin executes the logic from one of the scripts depending on which

--- a/plugin_config.txt
+++ b/plugin_config.txt
@@ -20,7 +20,7 @@ my $VEP_PLUGIN_CONFIG = {
       "requires_data" => 1,
       "requires_install" => 1,
       "params"  => [
-        #"/path/to/dbNSFP4.3a_grch38.gz",
+        #"/path/to/dbNSFP4.2a_grch38.gz",
         "@*"
       ],
       "species" => [
@@ -36,7 +36,7 @@ my $VEP_PLUGIN_CONFIG = {
           'multiple' => 1,
           'style' => 'height:150px',
           'required' => 1,
-          'notes' => 'Field descriptions in <a rel="external" href="https://usf.app.box.com/s/6yi6huheisol3bhmld8bitcon1oi53pm">dbNSFP README</a>',
+          'notes' => 'Field descriptions in <a rel="external" href="https://drive.google.com/file/d/1Vse3b_qw_E46eDcsuLegF5HxpodAZ6Og/view">dbNSFP README</a>',
           # "class" => "jquery-multiselect",
           "values" => [
             #"#chr",

--- a/plugin_config.txt
+++ b/plugin_config.txt
@@ -20,7 +20,7 @@ my $VEP_PLUGIN_CONFIG = {
       "requires_data" => 1,
       "requires_install" => 1,
       "params"  => [
-        #"/path/to/dbNSFP4.2a_grch38.gz",
+        #"/path/to/dbNSFP4.3a_grch38.gz",
         "@*"
       ],
       "species" => [
@@ -36,7 +36,7 @@ my $VEP_PLUGIN_CONFIG = {
           'multiple' => 1,
           'style' => 'height:150px',
           'required' => 1,
-          'notes' => 'Field descriptions in <a rel="external" href="https://drive.google.com/file/d/1Vse3b_qw_E46eDcsuLegF5HxpodAZ6Og/view">dbNSFP README</a>',
+          'notes' => 'Field descriptions in <a rel="external" href="https://usf.app.box.com/s/6yi6huheisol3bhmld8bitcon1oi53pm">dbNSFP README</a>',
           # "class" => "jquery-multiselect",
           "values" => [
             #"#chr",


### PR DESCRIPTION
## Description

Dataset website from MaxEntScan was updated to `http://hollywood.mit.edu/burgelab/maxent`. This PR is to change this URL in our documentation. PR based on issue https://github.com/Ensembl/VEP_plugins/issues/486.

## Test

1) Just click on new link and see it exists with necessary data from MaxEntScan.