### PR TITLE
Fix some issues on dbNSFP transcript_match feature

### DIFF
--- a/dbNSFP.pm
+++ b/dbNSFP.pm
@@ -175,6 +175,10 @@ my %NON_TRANSCRIPT_SPECIFIC_FIELDS = map {$_ => 1} qw(
   MutationTaster_pred
   MutationTaster_model
   Interpro_domain
+  MutPred_Top5features
+  Transcript_id_VEST3
+  Transcript_var_VEST3
+  VEST3_score
 );
 
 sub new {

--- a/dbNSFP.pm
+++ b/dbNSFP.pm
@@ -468,10 +468,21 @@ sub run {
       my @refine_fields = grep {defined($data->{$_}) && defined($self->{cols}->{$_})} @{$self->{transcript_specific_fields}};
 
       foreach my $key(@refine_fields) {
+	next if $data->{$key} eq '.';
+
         my @split = split(';', $data->{$key});
-        die("ERROR: Transcript index out of range") if $tr_index > $#split;
-        die("ERROR: Number of transcript IDs does not match number of data entries for field $key") if scalar @split != scalar @tr_ids;
-        $data->{$key} = $split[$tr_index];
+
+	if($tr_index > $#split) {
+          warn("ERROR: Transcript index out of range for field $key\n");
+	  next;
+        }
+
+	if(scalar @split != scalar @tr_ids) {
+	  warn("ERROR: Number of transcript IDs does not match number of data entries for field $key\n");
+	  next;
+        }
+	
+	$data->{$key} = $split[$tr_index];
       }
     }
     last;


### PR DESCRIPTION
This PR solves some issues on this [PR ](https://github.com/Ensembl/VEP_plugins/pull/461 ) that added transcript_match feature for dbNSFP plugin. 

When enabled transcript_match feature matches transcript and give value from that specific transcript from dbNSFP files for transcript specific fields instead of giving value from all the transcripts which can be confusing.

This PR fixes - 

- some fields that are not transcript specific
- the plugin to go on even if a transcript specific field cannot be filtered and give result for other fields. 