### PR TITLE
Improve GO plugin

### DIFF
--- a/GO.pm
+++ b/GO.pm
@@ -254,7 +254,7 @@ sub _generate_gff {
       '.' AS frame,
       transcript.stable_id AS transcript_stable_id,
       x.display_label AS go_term,
-      REPLACE(x.description, " ", "_") AS go_term_description
+      x.description AS go_term_description
       
     FROM transcript
     $join_translation_table
@@ -338,8 +338,20 @@ sub _write_GO_terms_to_file {
       # Append comma before appending another GO term
       $transcript_info .= ","
     }
+
+    if ( defined($description) ) {
+      $description =~ s/ /_/g; # Replace spaces with underscores
+
+      $description =~ s/,_/_-_/g; # Avoid commas followed by an underscore, e.g.:
+      # GO:0045892:negative_regulation_of_transcription,_DNA-templated
+
+      $description =~ s/,/-/g; # Avoid commas in other situtations, e.g.:
+      # GO:0016316:phosphatidylinositol-3,4-bisphosphate_4-phosphatase_activity
+    } else {
+      $description = "";
+    }
+
     # Append GO term and its description
-    $description = "" unless defined($description);
     $transcript_info .= "$go_term:$description";
   }
   # Write info of last transcript to file

--- a/GO.pm
+++ b/GO.pm
@@ -224,7 +224,7 @@ sub _generate_gff {
 
   my $config = $self->{config};
   die("ERROR: Cannot create GFF file in offline mode\n") if $config->{offline};
-  # die("ERROR: Cannot create GFF file in REST mode\n") if $config->{rest};
+  die("ERROR: Cannot create GFF file in REST mode\n") if $config->{rest};
   
   # test bgzip
   die "ERROR: bgzip does not seem to be in your path\n" unless `which bgzip 2>&1` =~ /bgzip$/;

--- a/GO.pm
+++ b/GO.pm
@@ -209,13 +209,12 @@ sub _prepare_filename {
   my $pkg      = __PACKAGE__.'.pm';
   my $species  = $config->{species};
   my $version  = $config->{db_version} || $reg->software_version;
-  my $assembly = $config->{assembly};
-  die "specify assembly using --assembly [assembly]\n" unless defined($assembly);
-
   my @basename = ($pkg, $species, $version);
+
   if( $species eq 'homo_sapiens' || $species eq 'human'){
-    $assembly ||= $config->{human_assembly};
-    push @basename, $assembly;
+    my $assembly = $config->{assembly} || $config->{human_assembly};
+    die "specify assembly using --assembly [assembly]\n" unless defined $assembly;
+    push @basename, $assembly if defined $assembly;
   }
   return $dir.join("_", @basename).".gff.gz";
 }

--- a/GO.pm
+++ b/GO.pm
@@ -80,7 +80,7 @@ sub new {
   $reg = 'Bio::EnsEMBL::Registry';
   
   # Check if parameter "remote" is provided to revert to old GO.pm functionality
-  $self->{use_remote} = grep($_ eq "remote", @{$self->params});
+  $self->{use_remote} = grep($_ eq "remote", @{$self->{params}});
   
   # Check if the tabix command is available
   if ( !$self->{use_remote} and !`which tabix 2>&1` =~ /tabix$/ ) {
@@ -199,8 +199,8 @@ sub _prepare_filename {
   
   # Prepare directory to store files
   my $dir = ""; # work in current directory by default
-  if (@{$self->params}) {
-    $dir = $self->params->[0];
+  if (@{$self->{params}}) {
+    $dir = $self->{params}->[0];
     $dir =~ s/\/?$/\//; # ensure path ends with slash
     die "ERROR: directory $dir does not exist\n" unless -e -d $dir;
   }

--- a/plugin_config.txt
+++ b/plugin_config.txt
@@ -1286,6 +1286,9 @@ my $VEP_PLUGIN_CONFIG = {
       "enabled" => 0,
       "plugin_url" => "https://raw.githubusercontent.com/Ensembl/VEP_plugins/release/107/GO.pm",
       "section" => "Phenotype data and citations",
+      "params" => [
+        #"/path/to/GO_data_dir"
+      ]
     },
 
     # G2P

--- a/plugin_config.txt
+++ b/plugin_config.txt
@@ -1281,7 +1281,7 @@ my $VEP_PLUGIN_CONFIG = {
     {
       "key" => "GO",
       "label" => "Gene Ontology",
-      "helptip" => "Retrieves Gene Ontology terms associated with transcripts/translations via the Ensembl API",
+      "helptip" => "Retrieves Gene Ontology terms associated with transcripts/translations",
       "available" => 0,
       "enabled" => 0,
       "plugin_url" => "https://raw.githubusercontent.com/Ensembl/VEP_plugins/release/107/GO.pm",


### PR DESCRIPTION
### [ENSVAR-4742](https://www.ebi.ac.uk/panda/jira/browse/ENSVAR-4742): improve support for REST and VEP web
* Avoid error when assembly is not defined
* Avoid creating GFF file in REST

**Testing**: No GTF file should be created in REST mode.

----

### [ENSVAR-4798](https://www.ebi.ac.uk/panda/jira/browse/ENSVAR-4798): avoid commas in GO description
* Replace commas followed by an underscore with `_-_`
  * e.g., `GO:0045892:negative_regulation_of_transcription,_DNA-templated`
* Replace commas in other situations with `_`
  * e.g., `GO:0016316:phosphatidylinositol-3,4-bisphosphate_4-phosphatase_activity`
* Replace spaces with underscore in Perl instead of SQL (for consistency with new changes)

Fixes issues with VCF output format where commas (usually only used to denote different entries) are replaced with `&`. Before this fix, VCF output could print the following for the GO terms: `GO:0045892:negative_regulation_of_transcription&_DNA-templated&GO:0005515:protein_binding`

**Testing:**
* Created GFF file and GO plugin results shouldn't have any commas besides the ones separating GO entries.
* The GO terms in the VCF files should be separated by `&`, but should have no `&` in the middle of GO term descriptions.

----

If needed, please check my [dev sandbox](http://wp-np2-11.ebi.ac.uk:6070/Homo_sapiens/Tools/VEP/Results?tl=fZeHWVdC2xfRpmXX-13) working for web and REST.