### PR TITLE
fix: REST assembly config to EVE

### DIFF
--- a/EVE.pm
+++ b/EVE.pm
@@ -96,7 +96,7 @@ sub new {
   $self->expand_left(0);
   $self->expand_right(0);
 
-  my $assembly = $self->{config}->{assembly};
+  my $assembly = $self->{config}->{assembly} || $config->{human_assembly};
 
   die "\nAssembly is not GRCh38, EVE only works with GRCh38. \n" if ($assembly ne "GRCh38");
 

--- a/EVE.pm
+++ b/EVE.pm
@@ -92,11 +92,12 @@ sub new {
   my $class = shift;
 
   my $self = $class->SUPER::new(@_);
+  my $config = $self->{config};
 
   $self->expand_left(0);
   $self->expand_right(0);
 
-  my $assembly = $self->{config}->{assembly} || $config->{human_assembly};
+  my $assembly = $config->{assembly} || $config->{human_assembly};
 
   die "\nAssembly is not GRCh38, EVE only works with GRCh38. \n" if ($assembly ne "GRCh38");
 


### PR DESCRIPTION
## Description

EVE plugin is not running in VEP REST due to absence of `config->assembly`. This PR is meant to fix this problem.

## Test

1) Run VEP in REST and make sure is still working in vep command-line.