### PR TITLE
Improve error message when running REVEL.pm with undefined assembly

### DIFF
--- a/REVEL.pm
+++ b/REVEL.pm
@@ -107,6 +107,7 @@ sub new {
   $self->{revel_file_columns} = $column_count;
 
   my $assembly = $self->{config}->{assembly};
+  die "specify assembly using --assembly [assembly]\n" unless defined $assembly;
 
   my %assembly_to_hdr = ('GRCh37' => 'hg19_pos',
                          'GRCh38' => 'grch38_pos');


### PR DESCRIPTION
Related with issue https://github.com/Ensembl/VEP_plugins/issues/518

When passing an undefined assembly (as it occurs if running VEP in offline mode), return a proper error informing the user to add argument `--assembly`:
```
specify assembly using --assembly [assembly]
```

### Testing

Test VEP in offline mode with and without defining assembly for REVEL.pm:
```
vep -i input.vcf --offline --plugin REVEL,new_tabbed_revel_grch38.tsv.gz
vep -i input.vcf --offline --asembly GRCh38 --plugin REVEL,new_tabbed_revel_grch38.tsv.gz
```
