### PR TITLE
Adding mutfunc plugin

### DIFF
--- a/mutfunc.pm
+++ b/mutfunc.pm
@@ -28,56 +28,44 @@ limitations under the License.
 =head1 SYNOPSIS
 
  mv mutfunc.pm ~/.vep/Plugins
- ./vep -i variations.vcf --plugin IntAct,mutation_file=/FULL_PATH_TO_IntAct_FILE/mutations.tsv,mapping_file=/FULL_PATH_TO_IntAct_FILE/mutation_gc_map.txt.gz
- ./vep -i variations.vcf --plugin IntAct,mutation_file=/FULL_PATH_TO_IntAct_FILE/mutations.tsv,mapping_file=/FULL_PATH_TO_IntAct_FILE/mutation_gc_map.txt.gz,minimal=1
+ ./vep -i variations.vcf --plugin mutfunc,motif=1,db=/FULL_PATH_TO/mutfunc_human_data.db
+ ./vep -i variations.vcf --plugin mutfunc,all=1,file=/FULL_PATH_TO/tfbs_tab.gz,db=/FULL_PATH_TO/mutfunc_human_data.db
 
 =head1 DESCRIPTION
 
- A VEP plugin that retrieves molecular interaction data for variants as reprted by IntAct database.
+ A VEP plugin that retrieves data from mutfunc db predicting destabilization of protein structure, interaction. regulatory region etc.
  
  Please cite the IntAct publication alongside the VEP if you use this resource:
- https://pubmed.ncbi.nlm.nih.gov/24234451/
+ https://www.embopress.org/doi/full/10.15252/msb.20188430
  
  Pre-requisites:
  
- 1) IntAct files can be downloaded from -
- http://ftp.ebi.ac.uk/pub/databases/intact/current/various
- 
- 2) The genomic location mapped file needs to be tabix indexed. You can 
- do this by following commands -
+ 1) mutfunc tfbs file can be downloaded from -
+ http://ftp.ebi.ac.uk/pub/databases/mutfunc/mutfunc_v2/ 
 
-  a) filter, sort and then zip
-  grep -v -e '^$' -e '^[#\-]' mutation_gc_map.txt | sed '1s/.*/#&/' | sort -k1,1 -k2,2n -k3,3n | bgzip > mutation_gc_map.txt.gz
+ mutfunc db can be downloaded from - ???
+ 
+ 2) The tfbs file needs to be tabix indexed. You can do this by following commands -
+
+  a) sort and zip
+  sed -i -e '1s/^/#/‘ tfbs.tab
+  grep -v ^"#" tfbs.tab | sort -k1,1 -k2,2n | bgzip > sorted_tfbs.tab.gz
   
   b) create tabix indexed file -
-  tabix -s 1 -b 2 -e 3 -f mutation_gc_map.txt.gz
+  tabix -s 1 -b 2 -e 2 -f sorted_tfbs.tab.gz
 
  3) As you have already noticed, tabix utility must be installed in your path to use this plugin.
  
  Options are passed to the plugin as key=value pairs:
 
- mapping_file			: (mandatory) Path to tabix-indexed genomic location mapped file
- mutation_file			: (mandatory) Path to IntAct data file
- 
- By default the output will always contain feature_type and interaction_ac from the IntAct data file. You can also add more fields using the following options -
- feature_ac			: Set value to 1 to include Feature AC in the output
- feature_short_label		: Set value to 1 to include Feature short label in the output
- feature_annotation		: Set value to 1 to include Feature annotation in the output
- ap_ac				: Set value to 1 to include Affected protein AC in the output
- interaction_participants	: Set value to 1 to include Interaction participants in the output
- pmid				: Set value to 1 to include PubMedID in the output
-
- There are also two other options for customizing the output - 
- all                            : Set value to 1 to include all the fields
- minimal                        : Set value to 1 to overwrite default behavior and include only interaction_ac 
-				  in the output by default
-
- See what this options mean - https://www.ebi.ac.uk/intact/download/datasets#mutations
- 
- Note that, interaction accession can be used to link to full details on the interaction website. For example, 
- where the VEP output reports an interaction_ac of EBI-12501485, the URL would be : 
-
-   https://www.ebi.ac.uk/intact/details/interaction/EBI-12501485
+ file		: Path to tabix-indexed tfbs data file. Mandatory if 'tfbs' or 'all' is selected
+ db			: Path to SQLite database containing data for other analysis. Mandatory 'motif', 'int', 'mod', 'exp' or 'all' is selected
+ motif  : Select this option to have mutfunc motif analysis in the output
+ int    : Select this option to have mutfunc protein interection analysis in the output
+ mod    : Select this option to have mutfunc protein structure analysis in the output
+ exp    : Select this option to have mutfunc protein structure (experimental) analysis in the output
+ tfbs   : Select this option to have mutfunc transcription factor binding site analysis in the output
+ all    : Select this option to have all of the above analysis in the output
 
 =cut
 

--- a/mutfunc.pm
+++ b/mutfunc.pm
@@ -29,7 +29,7 @@ limitations under the License.
 
  mv mutfunc.pm ~/.vep/Plugins
  ./vep -i variations.vcf --plugin mutfunc,motif=1,db=/FULL_PATH_TO/mutfunc_human_data.db
- ./vep -i variations.vcf --plugin mutfunc,all=1,file=/FULL_PATH_TO/tfbs_tab.gz,db=/FULL_PATH_TO/mutfunc_human_data.db
+ ./vep -i variations.vcf --plugin mutfunc,all=1,file=/FULL_PATH_TO/mutfunc_tfbs.tab.gz,db=/FULL_PATH_TO/mutfunc_human_data.db
 
 =head1 DESCRIPTION
 
@@ -49,10 +49,10 @@ limitations under the License.
 
   a) sort and zip
   sed -i -e '1s/^/#/‘ tfbs.tab
-  grep -v ^"#" tfbs.tab | sort -k1,1 -k2,2n | bgzip > sorted_tfbs.tab.gz
+  grep -v ^"#" tfbs.tab | sort -k1,1 -k2,2n | bgzip > mutfunc_tfbs.tab.gz
   
   b) create tabix indexed file -
-  tabix -s 1 -b 2 -e 2 -f sorted_tfbs.tab.gz
+  tabix -s 1 -b 2 -e 2 -f mutfunc_tfbs.tab.gz
 
  3) As you have already noticed, tabix utility must be installed in your path to use this plugin.
  

--- a/mutfunc.pm
+++ b/mutfunc.pm
@@ -83,6 +83,7 @@ limitations under the License.
 
 package mutfunc;
 
+use Data::Dumper;
 use strict;
 use warnings;
 use DBI;
@@ -91,34 +92,56 @@ use Digest::MD5 qw(md5_hex);
 use List::MoreUtils qw(first_index);
 
 use Bio::EnsEMBL::Utils::Exception qw(throw warning);
-use Bio::EnsEMBL::Variation::Utils::BaseVepPlugin;
+use Bio::EnsEMBL::Variation::Utils::Sequence qw(get_matched_variant_alleles);
+use Bio::EnsEMBL::Variation::Utils::BaseVepTabixPlugin;
 
-use base qw(Bio::EnsEMBL::Variation::Utils::BaseVepPlugin);
-
+use base qw(Bio::EnsEMBL::Variation::Utils::BaseVepTabixPlugin);
 
 my @ALL_AAS = qw(A C D E F G H I K L M N P Q R S T V W Y);
 
-# dispatch table for frunctions that parse item values
-my $parse_item_value = {
-  motif => \&parse_motif,
-  tfbs  => \&parse_tfbs
+my $field_order = {
+  motif => ["elm", "lost"],
+  int   => ["evidence", "dG_wt", "ddG", "dG_wt_sd", "dG_mt_sd", "ddG_sd"],
+  mod   => ["dG_wt", "ddG", "dG_wt_sd", "dG_mt_sd", "ddG_sd"],
+  exp   => ["dG_wt", "ddG", "dG_wt_sd", "dG_mt_sd", "ddG_sd"],
+  tfbs  => ["impact", "tf", "downstream", "g_strand", "s_strand", "wt_score", "mt_score", "ic_diff", "cells"]
 };
 
 sub new {
   my $class = shift;
   
   my $self = $class->SUPER::new(@_);
+
+  $self->expand_left(0);
+  $self->expand_right(0);
   
   my $param_hash = $self->params_to_hash();
 
-  die "ERROR: db is not specified which is a mandatory parameter\n" unless defined $param_hash->{db};
+  $self->{tfbs} = 1 if $param_hash->{tfbs} || $param_hash->{all};
 
-  $self->{db} = $param_hash->{db};
+  die "ERROR: tfbs file not specified but tfbs output is enabled\n" if ( (defined $self->{tfbs}) && !(defined $param_hash->{file}) );
+  $self->{file} = $param_hash->{file};
+
+  $self->add_file($self->{file}) if defined $self->{file};
 
   $self->{motif} = 1 if $param_hash->{motif} || $param_hash->{all};
   $self->{int} = 1 if $param_hash->{int} || $param_hash->{all};
   $self->{mod} = 1 if $param_hash->{mod} || $param_hash->{all};
   $self->{exp} = 1 if $param_hash->{exp} || $param_hash->{all};
+
+  die "ERROR: db is not specified but some of the options enabled require it\n" if ( 
+    ( (defined $self->{motif}) || 
+      (defined $self->{int}) || 
+      (defined $self->{mod}) || 
+      (defined $self->{exp}) 
+    ) && 
+    !(defined $param_hash->{db}) 
+  );
+  $self->{db} = $param_hash->{db};
+
+  if( ($self->{config}->{output_format} eq "json") || $self->{config}->{rest}){
+    $self->{output_json} = 1;
+  }
 
   $self->{initial_pid} = $$;
 
@@ -126,21 +149,21 @@ sub new {
 }
 
 sub feature_types {
-  return ['Transcript'];
+  return ['Transcript', 'Intergenic'];
 }
 
 sub get_header_info {
-  my $self = shift;
+  my ($self) = shift;
   
   my %header;
 
   $header{"mutfunc_motif"} = "Nonsynonymous mutations impact on linear motif from mutfunc db. ".
-  "Output fields are seperated by comma and include: ".
+  "Output fields are separated by ',' (or '&' for vcf format) and include: ".
   "elm - ELM accession of the linear motif, ".
   "lost - '1' if the mutation causes the motif to be lost and '0' otherwise" if defined $self->{motif};
 
   $header{"mutfunc_int"} = "Interaction interfaces destabilization analysis from mutfunc db. ".
-  "Output fields are seperated by comma and include: ".
+  "Output fields are separated by ',' (or '&' for vcf format) and include: ".
   "evidence - 'EXP' for experimental model and 'MDL' for homology models and 'MDD' for domain-domain homology models, ".
   "dG_wt - reference interface energy (kcal/mol), ".
   "dG_mt - mutated interface energy (kcal/mol), ".
@@ -150,7 +173,7 @@ sub get_header_info {
   "ddG_sd - ddG standard deviation (kcal/mol), " if defined $self->{int};
 
   $header{"mutfunc_mod"} = "Protein structure destabilization analysis (homology models) from mutfunc db. ".
-  "Output fields are seperated by comma and include: ".
+  "Output fields are separated by ',' (or '&' for vcf format) and include: ".
   "dG_wt - reference structure energy (kcal/mol), ".
   "dG_mt - mutated structure energy (kcal/mol), ".
   "ddG - change in structure stability between mutated and reference structure (kcal/mol) mutations where ddG >= 2 kcal/mol can be considered deleterious, ".
@@ -159,13 +182,25 @@ sub get_header_info {
   "ddG_sd - ddG standard deviation (kcal/mol), " if defined $self->{mod};
 
   $header{"mutfunc_exp"} = "Protein structure destabilization analysis (experimental models) from mutfunc db. ".
-  "Output fields are seperated by comma and include: ".
+  "Output fields are separated by ',' (or '&' for vcf format) and include: ".
   "dG_wt - reference structure energy (kcal/mol), ".
   "dG_mt - mutated structure energy (kcal/mol), ".
   "ddG - change in structure stability between mutated and reference structure (kcal/mol) mutations where ddG >= 2 kcal/mol can be considered deleterious, ".
   "dG_wt_sd - dG_wt standard deviation (kcal/mol), ".
   "dG_mt_sd - dG_mt standard deviation (kcal/mol), ".
   "ddG_sd - ddG standard deviation (kcal/mol), " if defined $self->{exp};
+
+  $header{"mutfunc_tfbs"} = "Transcription binding sites disruption analysis from mutfunc db. ".
+  "Output fields are separated by ',' (or '&' for vcf format) and include: ".
+  "impact -  1 if mutation is expected to disrupt the TFBS and 0 otherwise, ".
+  "tf - transcription factor predicted to bind this binding site, ".
+  "downstream - gene downstream from this TFBS, ".
+  "g_strand - strand containing the downstream gene, ".
+  "s_strand - strand containing binding site, ".
+  "wt_score - binding score of the transcription factor to the wildtype site, ".
+  "mt_score - binding score of the transcription factor to the mutated site".
+  "ic_diff - information content difference between the wildtype and mutant bases".
+  "cells - cell lines or tissues with evidence of chip-seq (human only) multiple cells are separated by 'and'" if defined $self->{tfbs};
    
   return \%header;
 }
@@ -210,8 +245,8 @@ sub parse_destabilizers {
     $item_value = substr $item_value, 2; 
 
     # get the value of the evidence
-    $evidence = undef $evidence == 0xFFFF;
-    my $evidence_val = defined $evidence ? $evidence_lval[$evidence] : undef;
+    $evidence = undef if $evidence == 0xFFFF;
+    $evidence_val = defined $evidence ? $evidence_lval[$evidence] : undef;
   }
   
   # get the rest
@@ -227,10 +262,70 @@ sub parse_destabilizers {
   return $dG_wt, $ddG, $dG_wt_sd, $dG_mt_sd, $ddG_sd;
 }
 
-sub run {
+sub format_output{
+  my ($self, $data, $item) = @_;
+
+  my $result = {};
+
+  if ($self->{output_json}){
+    my %hash = map { $_ => $data->{$_} } @{ $field_order->{$item} };
+    $result->{$item} = \%hash;
+  }
+  else{
+    my $key = "mutfunc_" . $item;
+    $result->{$key} = join(",", map { $data->{$_} } @{ $field_order->{$item} });
+  }
+
+  return $result;
+}
+
+sub process_from_file {
+  my ($self, $tva) = @_;
+
+  my $vf = $tva->variation_feature;
+  
+  # get allele
+  my $allele = $tva->variation_feature_seq;
+  return {} unless $allele =~ /^[ACGT-]+$/;
+
+  # get matched line from the file
+  my @data =  @{$self->get_data($vf->{chr}, $vf->{start} - 2, $vf->{end})};
+
+  # parse data and generate output
+  my $result_from_file = {};
+  foreach (@data) {
+    my $matches = get_matched_variant_alleles(
+      {
+        ref    => $vf->ref_allele_string,
+        alts   => [$allele],
+        pos    => $vf->{start},
+        strand => $vf->strand
+      },
+      {
+       ref  => $_->{ref},
+       alts => [$_->{alt}],
+       pos  => $_->{start},
+      }
+    );
+
+    if (@$matches){
+      my $result = $_->{result}; 
+      
+      $result->{cells} =~ s/,/and/g;
+
+      # we are not expecting multiple results so no code for joiing multiple results
+      $result_from_file = $self->format_output($result, "tfbs");
+    }
+  }
+
+  return $result_from_file;
+}
+
+sub process_from_db {
   my ($self, $tva) = @_;
 
   # get the trascript related to the variant
+  return {} unless $tva->can('transcript');
   my $tr = $tva->transcript;
 
   # get the translation
@@ -250,7 +345,7 @@ sub run {
   }
   $self->{get_sth}->execute($md5);
 
-  my $result = {};
+  my $result_from_db = {};
   while (my $arrayref = $self->{get_sth}->fetchrow_arrayref) {
     my $item = $arrayref->[1];
     my $matrix = $arrayref->[2];
@@ -269,70 +364,126 @@ sub run {
     my $peptide_number = (first_index { $_ eq $peptide } @ALL_AAS);
 
     # get matrix for each item value and parse them
+    # motif
     if ($item eq "motif" && $self->{motif}) {
+      # get the item value for specific pos and amino acid from matrix
       my $tot_packed_len = 26;
       my $item_value = retrieve_item_value($expanded_matrix, $pos, $peptide_number, $tot_packed_len);
 
       if ($item_value){
-        my ($elm, $lost) = $parse_item_value->{$item}($item_value);
+        # parse the item value from matrix
+        my ($elm, $lost) = parse_motif($item_value);
 
-        $result->{mutfunc_motif} = $elm if defined $elm;
-        $result->{mutfunc_motif} .= defined $lost ? ",".$lost : ",";
+        # format the output
+        my $formatted_output = {};
+        if(defined $elm || defined $lost){
+          $formatted_output = $self->format_output({
+            elm   => $elm,
+            lost  => $lost
+          }, $item);
+        }
 
-        # delete if there is no defined value
-        delete $result->{mutfunc_motif} unless $result->{mutfunc_motif} =~ /[^,]/;
+        @$result_from_db{ keys %$formatted_output } = values %$formatted_output;
       }
     }
-    elsif ($item eq "int" && $self->{int}) {
-      my $tot_packed_len = 42;
-      my $item_value = retrieve_item_value($expanded_matrix, $pos, $peptide_number, $tot_packed_len);
-
-      if ($item_value){
-        my ($evidence, $dG_wt, $ddG, $dG_wt_sd, $dG_mt_sd, $ddG_sd) = parse_destabilizers($item_value, $item);
-
-        # dG_mt can be calculated from dG_wt and ddG
-        my $dG_mt = (defined $dG_wt && defined $ddG) ? $dG_wt + $ddG : undef;
-
-        $result->{mutfunc_int} = $evidence if defined $evidence;
-        $result->{mutfunc_int} .= defined $dG_wt ? ",".$dG_wt : ",";
-        $result->{mutfunc_int} .= defined $dG_mt ? ",".$dG_mt : ",";
-        $result->{mutfunc_int} .= defined $ddG ? ",".$ddG : ",";
-        $result->{mutfunc_int} .= defined $dG_wt_sd ? ",".$dG_wt_sd : ",";
-        $result->{mutfunc_int} .= defined $dG_mt_sd ? ",".$dG_mt_sd : ",";
-        $result->{mutfunc_int} .= defined $ddG_sd ? ",".$ddG_sd : ",";
-
-        # delete if there is no defined value
-        delete $result->{mutfunc_int} unless $result->{mutfunc_int} =~ /[^,]/;
-      }
-    }
-    elsif ($item eq "mod" || $item eq "exp") {
-      if ($self->{$item}) {
-        my $tot_packed_len = 40;
+    # int and mod and exp
+    elsif ($item eq "int" || $item eq "mod" || $item eq "exp") {
+      if ($self->{$item}){
+        # get the item value for specific pos and amino acid from matrix
+        my $tot_packed_len = ($item eq "int") ? 42 : 40;
         my $item_value = retrieve_item_value($expanded_matrix, $pos, $peptide_number, $tot_packed_len);
 
         if ($item_value){
-          my ($dG_wt, $ddG, $dG_wt_sd, $dG_mt_sd, $ddG_sd) = parse_destabilizers($item_value, $item);;
+          # parse the item value from matrix
+          my ($evidence, $dG_wt, $ddG, $dG_wt_sd, $dG_mt_sd, $ddG_sd);
+          if ($item eq "int"){
+            ($evidence, $dG_wt, $ddG, $dG_wt_sd, $dG_mt_sd, $ddG_sd) = parse_destabilizers($item_value, $item);
+          }
+          else{
+            ($dG_wt, $ddG, $dG_wt_sd, $dG_mt_sd, $ddG_sd) = parse_destabilizers($item_value, $item);
+          }
 
           # dG_mt can be calculated from dG_wt and ddG
           my $dG_mt = (defined $dG_wt && defined $ddG) ? $dG_wt + $ddG : undef;
 
-          my $hash_key = "mutfunc_" . $item;
-          $result->{$hash_key} = $dG_wt if defined $dG_wt;
-          $result->{$hash_key} .= defined $dG_mt ? ",".$dG_mt : ",";
-          $result->{$hash_key} .= defined $ddG ? ",".$ddG : ",";
-          $result->{$hash_key} .= defined $dG_wt_sd ? ",".$dG_wt_sd : ",";
-          $result->{$hash_key} .= defined $dG_mt_sd ? ",".$dG_mt_sd : ",";
-          $result->{$hash_key} .= defined $ddG_sd ? ",".$ddG_sd : ",";
+          # format the output
+          my $formatted_output = {};
+          if(defined $evidence || defined $dG_wt || defined $ddG || defined $dG_wt_sd || defined $dG_mt_sd || defined $ddG_sd){
+            my $data = {
+              dG_wt   => $dG_wt,
+              dG_mt  => $dG_mt,
+              ddG   => $ddG,
+              dG_wt_sd  => $dG_wt_sd,
+              dG_mt_sd   => $dG_mt_sd,
+              ddG_sd  => $ddG_sd
+            };
 
-          # delete if there is no defined value
-          delete $result->{$hash_key} unless $result->{$hash_key} =~ /[^,]/;
+            $data->{evidence} = $evidence if (defined $evidence && $item eq "int");
+
+            $formatted_output = $self->format_output($data, $item);
+          }
+
+          @$result_from_db{ keys %$formatted_output } = values %$formatted_output;
         }
       }
     }
-    
   }
 
-  return $result;
+  return $result_from_db;
+}
+
+sub run {
+  my ($self, $tva) = @_;
+  
+  my $result = {};
+
+  # parse data file and generate result for tfbs
+  if($self->{tfbs}){
+    my $hash_from_file = $self->process_from_file($tva);
+    @$result{ keys %$hash_from_file } = values %$hash_from_file;
+  }
+  # connect to db and generate result from matrix for the other type of analysis
+  if($self->{motif} || $self->{int} || $self->{mod} || $self->{exp}){
+    my $hash_from_db = $self->process_from_db($tva);
+    @$result{ keys %$hash_from_db } = values %$hash_from_db;
+  }
+
+  return $self->{output_json} ? {"mutfunc" => $result} : $result;
+}
+
+sub parse_data {
+  my ($self, $line) = @_;
+  my ($c, $s, $ref, $alt, $del, undef, undef, undef, undef, undef, 
+    $tf, $downstream, undef, undef, $g_strand, $s_strand, 
+    $wt_score, $mt_score, undef, $ic_diff, undef, 
+    $cells) = split /\t/, $line;
+  
+  return {
+    chr => $c,
+    start => $s,
+    end => $s,
+    ref => $ref,
+    alt => $alt,
+    result => {
+      impact => $del, 
+      tf => $tf, 
+      downstream => $downstream, 
+      g_strand => $g_strand,
+      s_strand => $s_strand, 
+      wt_score => $wt_score,
+      mt_score => $mt_score,
+      ic_diff => $ic_diff,
+      cells => $cells
+    }
+  };
+}
+
+sub get_start { 
+  return $_[1]->{start};
+}
+
+sub get_end {
+  return $_[1]->{end};
 }
 
 1;

--- a/mutfunc.pm
+++ b/mutfunc.pm
@@ -1,0 +1,277 @@
+=head1 LICENSE
+
+Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
+Copyright [2016-2022] EMBL-European Bioinformatics Institute
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=head1 CONTACT
+
+ Ensembl <http://www.ensembl.org/info/about/contact/index.html>
+    
+=cut
+
+=head1 NAME
+
+ mutfunc
+
+=head1 SYNOPSIS
+
+ mv mutfunc.pm ~/.vep/Plugins
+ ./vep -i variations.vcf --plugin IntAct,mutation_file=/FULL_PATH_TO_IntAct_FILE/mutations.tsv,mapping_file=/FULL_PATH_TO_IntAct_FILE/mutation_gc_map.txt.gz
+ ./vep -i variations.vcf --plugin IntAct,mutation_file=/FULL_PATH_TO_IntAct_FILE/mutations.tsv,mapping_file=/FULL_PATH_TO_IntAct_FILE/mutation_gc_map.txt.gz,minimal=1
+
+=head1 DESCRIPTION
+
+ A VEP plugin that retrieves molecular interaction data for variants as reprted by IntAct database.
+ 
+ Please cite the IntAct publication alongside the VEP if you use this resource:
+ https://pubmed.ncbi.nlm.nih.gov/24234451/
+ 
+ Pre-requisites:
+ 
+ 1) IntAct files can be downloaded from -
+ http://ftp.ebi.ac.uk/pub/databases/intact/current/various
+ 
+ 2) The genomic location mapped file needs to be tabix indexed. You can 
+ do this by following commands -
+
+  a) filter, sort and then zip
+  grep -v -e '^$' -e '^[#\-]' mutation_gc_map.txt | sed '1s/.*/#&/' | sort -k1,1 -k2,2n -k3,3n | bgzip > mutation_gc_map.txt.gz
+  
+  b) create tabix indexed file -
+  tabix -s 1 -b 2 -e 3 -f mutation_gc_map.txt.gz
+
+ 3) As you have already noticed, tabix utility must be installed in your path to use this plugin.
+ 
+ Options are passed to the plugin as key=value pairs:
+
+ mapping_file			: (mandatory) Path to tabix-indexed genomic location mapped file
+ mutation_file			: (mandatory) Path to IntAct data file
+ 
+ By default the output will always contain feature_type and interaction_ac from the IntAct data file. You can also add more fields using the following options -
+ feature_ac			: Set value to 1 to include Feature AC in the output
+ feature_short_label		: Set value to 1 to include Feature short label in the output
+ feature_annotation		: Set value to 1 to include Feature annotation in the output
+ ap_ac				: Set value to 1 to include Affected protein AC in the output
+ interaction_participants	: Set value to 1 to include Interaction participants in the output
+ pmid				: Set value to 1 to include PubMedID in the output
+
+ There are also two other options for customizing the output - 
+ all                            : Set value to 1 to include all the fields
+ minimal                        : Set value to 1 to overwrite default behavior and include only interaction_ac 
+				  in the output by default
+
+ See what this options mean - https://www.ebi.ac.uk/intact/download/datasets#mutations
+ 
+ Note that, interaction accession can be used to link to full details on the interaction website. For example, 
+ where the VEP output reports an interaction_ac of EBI-12501485, the URL would be : 
+
+   https://www.ebi.ac.uk/intact/details/interaction/EBI-12501485
+
+=cut
+
+package mutfunc;
+
+use strict;
+use warnings;
+use DBI;
+use Compress::Zlib;
+use Digest::MD5 qw(md5_hex);
+use List::MoreUtils qw(first_index);
+
+use Bio::EnsEMBL::Utils::Exception qw(warning);
+use Bio::EnsEMBL::Variation::Utils::BaseVepPlugin;
+
+use base qw(Bio::EnsEMBL::Variation::Utils::BaseVepPlugin);
+
+
+my @ALL_AAS = qw(A C D E F G H I K L M N P Q R S T V W Y);
+
+# dispatch table for frunctions to retrieve items
+my $retrieve_item = {
+  motif_elm => \&retrieve_motif_elm,
+  motif_lost => \&retrieve_motif_lost,
+  int_evidence => \&retrieve_int_evidence,
+  energy => \&retrieve_energy
+};
+
+sub new {
+  my $class = shift;
+  
+  my $self = $class->SUPER::new(@_);
+  
+  my $param_hash = $self->params_to_hash();
+
+  die "ERROR: db is not specified which is a mandatory parameter\n" unless defined $param_hash->{db};
+
+  $self->{db} = $param_hash->{db};
+
+  $self->{motif} = 1 if $param_hash->{motif} || $param_hash->{all};
+  $self->{int} = 1 if $param_hash->{int} || $param_hash->{all};
+
+  $self->{initial_pid} = $$;
+
+  return $self;
+}
+
+sub feature_types {
+  return ['Transcript'];
+}
+
+sub get_header_info {
+  my $self = shift;
+  
+  my %header;
+
+  $header{"mutfunc_motif"} = "Nonsynonymous mutations impact on linear motif from mutfunc db. ".
+  "Output fields are seperated by comma and include: ".
+  "elm - ELM accession of the linear motif, ".
+  "lost - '1' if the mutation causes the motif to be lost and '0' otherwise";
+
+  $header{"mutfunc_int"} = "Interaction interfaces destabilization analysis from mutfunc db. ".
+  "Output fields are seperated by comma and include: ".
+  "evidence - 'EXP' for experimental model and 'MDL' for homology models and 'MDD' for domain-domain homology models, ".
+  "dG_wt - reference interface energy (kcal/mol), ".
+  "dG_mt - mutated interface energy (kcal/mol), ".
+  "ddG - change in interface stability between mutated and reference structure (kcal/mol) mutations with ddG >= 2 kcal/mol can be considered deleterious, ".
+  "dG_wt_sd - dG_wt standard deviation (kcal/mol), ".
+  "dG_mt_sd - dG_mt standard deviation (kcal/mol), ".
+  "ddG_sd - ddG standard deviation (kcal/mol), ";
+   
+  return \%header;
+}
+
+sub expand_matrix {
+  my ($matrix) = @_;
+
+  my $expanded_matrix = Compress::Zlib::memGunzip($matrix) or 
+    throw("Failed to gunzip: $gzerrno");
+
+  return $expanded_matrix;
+}
+
+sub retrieve_motif_elm {
+  my ($matrix, $pos, $aa) = @_;
+
+  my $packed_len = 24;
+  my $item_value = (unpack "A24", substr($matrix, $pos * $packed_len * 20 + $aa * $packed_len, $packed_len) );
+
+  return undef if $item_value eq "undefined";
+  return $item_value;
+}
+
+sub retrieve_motif_lost {
+  my ($matrix, $pos, $aa) = @_;
+
+  my $packed_len = 2;
+  my $item_value = (unpack "v", substr($matrix, $pos * $packed_len * 20 + $aa * $packed_len, $packed_len) );
+
+  return undef if $item_value == 0xFFFF;
+  return $item_value;
+}
+
+sub retrieve_int_evidence {
+  my ($matrix, $pos, $aa) = @_;
+
+  my @evidence_sval = qw(EXP MDD MDL);
+
+  my $packed_len = 2;
+  my $item_value = (unpack "v", substr($matrix, $pos * $packed_len * 20 + $aa * $packed_len, $packed_len) );
+
+  return undef if $item_value == 0xFFFF;
+  return $evidence_sval[$item_value];
+}
+
+sub retrieve_energy {
+  my ($matrix, $pos, $aa) = @_;
+
+  my $packed_len = 8;
+  my $item_value = (unpack "A8", substr($matrix, $pos * $packed_len * 20 + $aa * $packed_len, $packed_len) );
+
+  return undef if $item_value eq "100000000";
+  return $item_value;
+}
+
+sub run {
+  my ($self, $tva) = @_;
+
+  # get the trascript related to the variant
+  my $tr = $tva->transcript;
+
+  # get the translation
+  my $translation = $tr->translate;
+  return {} unless $translation;
+
+  # get the md5 hash of the peptide sequence
+  my $md5 = md5_hex($translation->seq);
+
+  # forked, reconnect to DB
+  if($$ != $self->{initial_pid}) {
+    $self->{dbh} = DBI->connect("dbi:SQLite:dbname=".$self->{db},"","");
+    $self->{get_sth} = $self->{dbh}->prepare("SELECT md5, item, matrix FROM consequences WHERE md5 = ?");
+
+    # set this so only do once per fork
+    $self->{initial_pid} = $$;
+  }
+  $self->{get_sth}->execute($md5);
+
+  my $result = {};
+  while (my $arrayref = $self->{get_sth}->fetchrow_arrayref) {
+    my $item = $arrayref->[1];
+    my $matrix = $arrayref->[2];
+
+    # expand the compressed matrix
+    my $expanded_matrix = expand_matrix($matrix);
+
+    # position and peptide to retrieve value from matrix
+    my $pos = $tva->transcript_variation->translation_start;
+    my $peptide = $tva->peptide;
+
+    # in matrix position is 0 indexed
+    $pos--;
+
+    # we need position of peptide in the ALL_AAS array
+    my $peptide_number = (first_index { $_ eq $peptide } @ALL_AAS);
+
+    if ($item =~ /motif*/ && $self->{motif}) {
+      my $item_value = $retrieve_item->{$item}($expanded_matrix, $pos, $peptide_number);
+
+      if ($item_value){
+        unless (defined $result->{mutfunc_motif}) {
+          $result->{mutfunc_motif} = $item_value;
+        }
+        else{
+          $result->{mutfunc_motif} = $result->{mutfunc_motif}.",".$item_value;
+        }
+      }
+    }
+    elsif ($item =~ /int*/ && $self->{int}) {
+      my $item_retrieval = $item eq "int_evidence" ? $item : "energy";
+      my $item_value = $retrieve_item->{$item_retrieval}($expanded_matrix, $pos, $peptide_number);
+
+      if ($item_value){
+        unless (defined $result->{mutfunc_int}) {
+          $result->{mutfunc_int} = $item_value;
+        }
+        else{
+          $result->{mutfunc_int} = $result->{mutfunc_int}.",".$item_value;
+        }
+      }
+    }
+  }
+
+  return $result;
+}
+
+1;

--- a/mutfunc.pm
+++ b/mutfunc.pm
@@ -91,9 +91,9 @@ my @ALL_AAS = qw(A C D E F G H I K L M N P Q R S T V W Y);
 
 my $field_order = {
   motif => ["elm", "lost"],
-  int   => ["evidence", "dG_wt", "ddG", "dG_wt_sd", "dG_mt_sd", "ddG_sd"],
-  mod   => ["dG_wt", "ddG", "dG_wt_sd", "dG_mt_sd", "ddG_sd"],
-  exp   => ["dG_wt", "ddG", "dG_wt_sd", "dG_mt_sd", "ddG_sd"],
+  int   => ["evidence", "dG_wt", "dG_mt", "ddG", "dG_wt_sd", "dG_mt_sd", "ddG_sd"],
+  mod   => ["dG_wt", "dG_mt", "ddG", "dG_wt_sd", "dG_mt_sd", "ddG_sd"],
+  exp   => ["dG_wt", "dG_mt", "ddG", "dG_wt_sd", "dG_mt_sd", "ddG_sd"],
   tfbs  => ["impact", "tf", "downstream", "g_strand", "s_strand", "wt_score", "mt_score", "ic_diff", "cells"]
 };
 
@@ -302,9 +302,9 @@ sub process_from_file {
         strand => $vf->strand
       },
       {
-       ref  => $_->{ref},
-       alts => [$_->{alt}],
-       pos  => $_->{start},
+        ref  => $_->{ref},
+        alts => [$_->{alt}],
+        pos  => $_->{start},
       }
     );
 

--- a/mutfunc.pm
+++ b/mutfunc.pm
@@ -41,7 +41,7 @@ limitations under the License.
  Pre-requisites:
  
  1) The data file. mutfunc SQLite db can be downloaded from - 
- http://ftp.ensembl.org/pub/current_variation/variation/mutfunc/
+ http://ftp.ensembl.org/pub/current_variation/variation/mutfunc/mutfunc_data.db
  
  Options are passed to the plugin as key=value pairs:
 

--- a/mutfunc.pm
+++ b/mutfunc.pm
@@ -458,6 +458,7 @@ sub run {
     @$result{ keys %$hash_from_db } = values %$hash_from_db;
   }
 
+  return {} unless %$result;
   return $self->{output_json} ? {"mutfunc" => $result} : $result;
 }
 

--- a/mutfunc.pm
+++ b/mutfunc.pm
@@ -28,16 +28,15 @@ limitations under the License.
 =head1 SYNOPSIS
 
  mv mutfunc.pm ~/.vep/Plugins
- ./vep -i variations.vcf --plugin mutfunc,motif=1,db=/FULL_PATH_TO/mutfunc_human_data.db
- ./vep -i variations.vcf --plugin mutfunc,all=1,file=/FULL_PATH_TO/mutfunc_tfbs.tab.gz,db=/FULL_PATH_TO/mutfunc_human_data.db
- ./vep -i variations.vcf --plugin mutfunc,all=1,extended=1,file=/FULL_PATH_TO/mutfunc_tfbs.tab.gz,db=/FULL_PATH_TO/mutfunc_human_data.db
+ ./vep -i variations.vcf --plugin mutfunc,motif=1,db=/FULL_PATH_TO/mutfunc_data.db
+ ./vep -i variations.vcf --plugin mutfunc,all=1,extended=1,db=/FULL_PATH_TO/mutfunc_data.db
 
 =head1 DESCRIPTION
 
  A VEP plugin that retrieves data from mutfunc db predicting destabilization of protein structure, interaction. regulatory region etc.
  
- Please cite the IntAct publication alongside the VEP if you use this resource:
- https://www.embopress.org/doi/full/10.15252/msb.20188430
+ Please cite the mutfunc publication alongside the VEP if you use this resource:
+ http://msb.embopress.org/content/14/12/e8430
  
  Pre-requisites:
  
@@ -46,7 +45,6 @@ limitations under the License.
  
  Options are passed to the plugin as key=value pairs:
 
- file		  : Path to tabix-indexed tfbs data file. Mandatory if 'tfbs' or 'all' is selected
  db			  : Path to SQLite database containing data for other analysis. Mandatory 'motif', 'int', 'mod', 'exp' or 'all' is selected
  motif    : Select this option to have mutfunc motif analysis in the output
  int      : Select this option to have mutfunc protein interection analysis in the output

--- a/mutfunc.pm
+++ b/mutfunc.pm
@@ -44,7 +44,8 @@ limitations under the License.
  1) mutfunc tfbs file can be downloaded from -
  http://ftp.ebi.ac.uk/pub/databases/mutfunc/mutfunc_v2/ 
 
- mutfunc db can be downloaded from - ???
+ mutfunc db can be downloaded from - 
+ http://ftp.ensembl.org/pub/current_variation/variation/mutfunc/
  
  2) The tfbs file needs to be tabix indexed. You can do this by following commands -
 

--- a/plugin_config.txt
+++ b/plugin_config.txt
@@ -1720,11 +1720,10 @@ my $VEP_PLUGIN_CONFIG = {
           "multiple" => 1,
           "style" => "height:150px",
           "values" => [
-            { "value" => "motif=1", "caption" => "motif", "helptip" => "Effect on linear motifs", 'checked' => 1 },
-            { "value" => "int=1", "caption" => "int", "helptip" => "Effect on protein interactions", 'checked' => 1 },
-            { "value" => "mod=1", "caption" => "mod", "helptip" => "Effect on protein structure", 'checked' => 1 },
-            { "value" => "exp=1", "caption" => "exp", "helptip" => "Effect on protein structure (experimental)", 'checked' => 1 },
-            { "value" => "tfbs=1", "caption" => "tfbs", "helptip" => "Effect on transcription factor binding site", 'checked' => 1 },
+            { "value" => "motif=1", "caption" => "Linear Motifs", "helptip" => "Effect on linear motifs", 'checked' => 1 },
+            { "value" => "int=1", "caption" => "Protein Interactions", "helptip" => "Effect on protein interactions", 'checked' => 1 },
+            { "value" => "mod=1", "caption" => "Protein Structure", "helptip" => "Effect on protein structure", 'checked' => 1 },
+            { "value" => "exp=1", "caption" => "Protein Structure (exp.)", "helptip" => "Effect on protein structure (experimental)", 'checked' => 1 }
           ],
         },
         {

--- a/plugin_config.txt
+++ b/plugin_config.txt
@@ -1707,7 +1707,8 @@ my $VEP_PLUGIN_CONFIG = {
         "@*"
       ],
       "species" => [
-        "homo_sapiens"
+        "homo_sapiens",
+        "saccharomyces_cerevisiae"
       ],
       "form" => [
         {

--- a/plugin_config.txt
+++ b/plugin_config.txt
@@ -1703,7 +1703,7 @@ my $VEP_PLUGIN_CONFIG = {
       "plugin_url" => "https://raw.githubusercontent.com/Ensembl/VEP_plugins/release/108/mutfunc.pm",
       "requires_data" => 1,
       "params"  => [
-        "#db=/path/to/mutfunc_human_data.db",
+        "#db=/path/to/mutfunc_data.db",
         "@*"
       ],
       "species" => [

--- a/plugin_config.txt
+++ b/plugin_config.txt
@@ -1692,6 +1692,51 @@ my $VEP_PLUGIN_CONFIG = {
       ]
     },
 
+    # mutfunc
+    {
+      "key" => "mutfunc",
+      "label" => "mutfunc",
+      "available" => 0,
+      "enabled" => 0,
+      "section" => "Protein annotation",
+      "helptip" => "mutfunc predicts destabilization effect of protein structure, interaction, regulatory region etc. caused by a variant",
+      "plugin_url" => "https://raw.githubusercontent.com/Ensembl/VEP_plugins/release/108/mutfunc.pm",
+      "requires_data" => 1,
+      "params"  => [
+        "#db=/path/to/mutfunc_human_data.db",
+        "@*"
+      ],
+      "species" => [
+        "homo_sapiens"
+      ],
+      "form" => [
+        {
+          "name" => "mutfunc_fields",
+          "label" => "Fields to include",
+          "helptip" => "Select which analysis you want to see in the output",
+          "value" => "",
+          "type" => "checklist",
+          "multiple" => 1,
+          "style" => "height:150px",
+          "values" => [
+            { "value" => "motif=1", "caption" => "motif", "helptip" => "Effect on linear motifs", 'checked' => 1 },
+            { "value" => "int=1", "caption" => "int", "helptip" => "Effect on protein interactions", 'checked' => 1 },
+            { "value" => "mod=1", "caption" => "mod", "helptip" => "Effect on protein structure", 'checked' => 1 },
+            { "value" => "exp=1", "caption" => "exp", "helptip" => "Effect on protein structure (experimental)", 'checked' => 1 },
+            { "value" => "tfbs=1", "caption" => "tfbs", "helptip" => "Effect on transcription factor binding site", 'checked' => 1 },
+          ],
+        },
+        {
+          "name" => "mutfunc_extend",
+          "label" => "Extended output",
+          "helptip" => "By default mutfunc outputs the most significant field for any analysis. Select this option to get more verbose output.",
+          "value" => "extended=1",
+          "type" => "checkbox",
+          "style" => "height:150px"
+        }
+      ]
+    },
+
 
     ## OTHER
     ########


### PR DESCRIPTION
Mutfunc website - http://www.mutfunc.com/help

Mutfunc have several analysis and corresponding output file for them. We have built the plugin for 4 of them - 
motif.tab - effects on linear motif
int.tab - effects on interaction 
mod.tab - effects on protein structure
exp.tab - effects on protein structure (experimental)
~~tfbs.tab - effects on transcription factor binding site~~ (removed due to mismatch in sequnence)

For the first 4 of them do not have genomic location and described with protein location informtaion. That is why we have built a SQLite database for them with similar fashion how we have our protein function table. So it has a single table `consequences (species, md5, item, matrix)` where we are storing a 2D matrix against each transcript md5 and each analysis.
(at first, I was planning to separate and format some of the fields each analysis have and called them items but now I am storing all of the fields of an analysis into a single entries in the matrix. But the name `item` remained).

You can grab a database from - `/hps/nobackup/flicek/ensembl/variation/snhossain/issues/ensvar-4505/scripts/mutfunc_data.db`

Example command for test - 
```
perl /hps/software/users/ensembl/repositories/snhossain/ensembl-vep/vep \
--i /hps/nobackup/flicek/ensembl/variation/snhossain/issues/ensvar-4505/data/motif_test \
--o /hps/nobackup/flicek/ensembl/variation/snhossain/issues/ensvar-4505/output/test_result.txt \
--offline \
--fork 2 \
--dir_cache /nfs/production/flicek/ensembl/variation/data/VEP/tabixconverted \
--cache_version 106 \
--assembly GRCh38 \
--fasta /nfs/production/flicek/ensembl/variation/data/Homo_sapiens.GRCh38.dna.toplevel.fa.gz \
--force_overwrite \
--plugin mutfunc,motif=1,db=/hps/nobackup/flicek/ensembl/variation/snhossain/issues/ensvar-4505/scripts/mutfunc_data.db
```
