### PR TITLE
Extend IntAct data matching

### DIFF
--- a/IntAct.pm
+++ b/IntAct.pm
@@ -243,9 +243,14 @@ sub _get_species_tax_id {
   unless( defined $json_response->{id} and $json_response->{id} ne "" ) {
     warning "WARNING: cannot parse taxonomy id from response content; only human will be supported\n";
     return;
-  }  
-  
-  $self->{species_tax_id} = $json_response->{id};
+  }
+
+  # add taxonomy id including the children
+  $self->{species_tax_id} = [ $json_response->{id} ]; 
+  foreach (@{ $json_response->{children} }){
+    push $self->{species_tax_id}, $_->{id};
+  }
+
   return $self->{species_tax_id};
 }
 
@@ -317,7 +322,7 @@ sub _remove_duplicates {
       my $ap_organism_tax_id = (split /-/, $parsed_data->{ap_organism})[0];
       $ap_organism_tax_id =~ s/^\s+|\s+$//;
 
-      next if $ap_organism_tax_id ne $self->{species_tax_id};
+      next unless exists $self->{species_tax_id}, $ap_organism_tax_id;
     }
     else {
       next if $parsed_data->{ap_organism} ne "9606 - Homo sapiens";


### PR DESCRIPTION
- Fix: some species like chicken RJF had gca in their name and it was failing taxonomy id lookup. So removed gca from species name.
- Improvement: we were exactly matching the HGVS description. For example, if from genomic location file we got a HGVS description like `p.Pro712Ala` we were looking for the exact same match from the data file. But instead, for this instance, the data file had `p.[Pro712Ala;Pro715Ala]` and the match failed. We are now allowing this match because the allele `p.[Pro712Ala;Pro715Ala]` at least contains the variant we are looking for irrespective of whatever the additional information that the data line contains.