### PR TITLE
G2P check af_threshold is defined

### DIFF
--- a/G2P.pm
+++ b/G2P.pm
@@ -711,7 +711,7 @@ sub variants_filtered_by_frequency_threshold {
   foreach my $variant (@$variants) {
     # get the highest frequency that has been observed for the variant
     my $highest_frequency = $self->highest_frequency($variant);
-    if (! defined $highest_frequency || $highest_frequency <= $af_threshold ||
+    if (! defined $highest_frequency || (defined $af_threshold && $highest_frequency <= $af_threshold) ||
          $self->{g2p_vf_cache}->{$variant}->{is_on_variant_include_list}
     ) {
       push @pass_variants, $variant;


### PR DESCRIPTION
Check if $af_threshold is defined to avoid the following message:
`Use of uninitialized value $af_threshold in numeric le (<=) at /home/u035/u035/shared/software/bcbio/anaconda/share/ensembl-vep-100.4-0/G2P.pm line 653, <_ANONIO_> line 15403.`

Details: [ENSVAR-4804](https://www.ebi.ac.uk/panda/jira/browse/ENSVAR-4804)