### PR TITLE
Update ftp links to https

### DIFF
--- a/AncestralAllele.pm
+++ b/AncestralAllele.pm
@@ -35,13 +35,13 @@ limitations under the License.
  A VEP plugin that retrieves ancestral allele sequences from a FASTA file.
 
  Ensembl produces FASTA file dumps of the ancestral sequences of key species.
- They are available from ftp://ftp.ensembl.org/pub/current_fasta/ancestral_alleles/
+ They are available from https://ftp.ensembl.org/pub/current_fasta/ancestral_alleles/
 
  For optimal retrieval speed, you should pre-process the FASTA files into a single
  bgzipped file that can be accessed via Bio::DB::HTS::Faidx (installed by VEP's
  INSTALL.pl):
 
- wget ftp://ftp.ensembl.org/pub/current_fasta/ancestral_alleles/homo_sapiens_ancestor_GRCh38.tar.gz
+ wget https://ftp.ensembl.org/pub/current_fasta/ancestral_alleles/homo_sapiens_ancestor_GRCh38.tar.gz
  tar xfz homo_sapiens_ancestor_GRCh38.tar.gz
  cat homo_sapiens_ancestor_GRCh38/*.fa | bgzip -c > homo_sapiens_ancestor_GRCh38.fa.gz
  rm -rf homo_sapiens_ancestor_GRCh38/ homo_sapiens_ancestor_GRCh38.tar.gz

--- a/Conservation.pm
+++ b/Conservation.pm
@@ -47,7 +47,7 @@ limitations under the License.
  the 2 flanking bases will be returned.
 
  The plugin uses the ensembl-compara API module (optional, see http://www.ensembl.org/info/docs/api/index.html)
- or obtains data directly from BigWig files (optional, see ftp://ftp.ensembl.org/pub/current_compara/conservation_scores/)
+ or obtains data directly from BigWig files (optional, see https://ftp.ensembl.org/pub/current_compara/conservation_scores/)
 
 =cut
 package Conservation;
@@ -140,7 +140,7 @@ sub run {
   #if it doesn't look like the user has given an FTP link or a file, try and find the correct data
   if(@{$self->params}[0] !~ /ftp.ensembl.org/ && not -f @{$self->params}[0])
   {
-    my $FTP_URL = "ftp://ftp.ensembl.org/pub/current_compara/conservation_scores/";
+    my $FTP_URL = "https://ftp.ensembl.org/pub/current_compara/conservation_scores/";
     my $FTP_USER = 'anonymous';  
 
     $FTP_URL =~ m/(ftp:\/\/)?(.+?)\/(.+)/;  

--- a/ExAC.pm
+++ b/ExAC.pm
@@ -39,7 +39,7 @@ limitations under the License.
 
  A VEP plugin that retrieves ExAC allele frequencies.
  
- Visit ftp://ftp.broadinstitute.org/pub/ExAC_release/current to download the latest ExAC VCF.
+ Visit https://ftp.broadinstitute.org/pub/ExAC_release/current to download the latest ExAC VCF.
  
  Note that the currently available version of the ExAC data file (0.3) is only available
  on the GRCh37 assembly; therefore it can only be used with this plugin when using the
@@ -105,7 +105,7 @@ sub new {
 
   # check files exist
   else {
-    die "ERROR: ExAC file $file not found; you can download it from ftp://ftp.broadinstitute.org/pub/ExAC_release/current\n" unless -e $file;
+    die "ERROR: ExAC file $file not found; you can download it from https://ftp.broadinstitute.org/pub/ExAC_release/current\n" unless -e $file;
     die "ERROR: Tabix index file $file\.tbi not found - perhaps you need to create it first?\n" unless -e $file.'.tbi';
   }
   

--- a/FlagLRG.pm
+++ b/FlagLRG.pm
@@ -34,7 +34,7 @@ limitations under the License.
  A VEP plugin that retrieves the LRG ID matching either the RefSeq or Ensembl
  transcript IDs. You can obtain the 'list_LRGs_transcripts_xrefs.txt' using:
 
- > wget ftp://ftp.ebi.ac.uk/pub/databases/lrgex/list_LRGs_transcripts_xrefs.txt
+ > wget https://ftp.ebi.ac.uk/pub/databases/lrgex/list_LRGs_transcripts_xrefs.txt
 
 =cut
 

--- a/IntAct.pm
+++ b/IntAct.pm
@@ -41,7 +41,7 @@ limitations under the License.
  Pre-requisites:
  
  1) IntAct files can be downloaded from -
- http://ftp.ebi.ac.uk/pub/databases/intact/current/various
+ https://ftp.ebi.ac.uk/pub/databases/intact/current/various
  
  2) The genomic location mapped file needs to be tabix indexed. You can 
  do this by following commands -

--- a/LD.pm
+++ b/LD.pm
@@ -98,21 +98,21 @@ limitations under the License.
 
    mkdir variation_genotype
    cd variation_genotype
-   lftp -e "mget ALL.chr*.phase3_shapeit2_mvncall_integrated_v3plus_nounphased.rsID.genotypes.GRCh38_dbSNP.vcf.gz*" ftp://ftp.ensembl.org/pub/data_files/homo_sapiens/GRCh38/variation_genotype/
+   lftp -e "mget ALL.chr*.phase3_shapeit2_mvncall_integrated_v3plus_nounphased.rsID.genotypes.GRCh38_dbSNP.vcf.gz*" https://ftp.ensembl.org/pub/data_files/homo_sapiens/GRCh38/variation_genotype/
    cd ..
 
  For GRCh37 replace the lftp command with:
 
-   lftp -e "mget ALL.chr*.phase3_shapeit2_mvncall_integrated_v3plus_nounphased.rsID.genotypes.vcf.gz*" ftp://ftp.ensembl.org/pub/data_files/homo_sapiens/GRCh37/variation_genotype/
+   lftp -e "mget ALL.chr*.phase3_shapeit2_mvncall_integrated_v3plus_nounphased.rsID.genotypes.vcf.gz*" https://ftp.ensembl.org/pub/data_files/homo_sapiens/GRCh37/variation_genotype/
 
  We must now modify the JSON configuration file used to find the data. Starting
  in the ensembl-vep directory:
 
-   perl -pi -e "s|ftp://ftp.ensembl.org/pub/data_files/homo_sapiens/GRCh38|$PWD|" Bio/EnsEMBL/Variation/DBSQL/vcf_config.json
+   perl -pi -e "s|https://ftp.ensembl.org/pub/data_files/homo_sapiens/GRCh38|$PWD|" Bio/EnsEMBL/Variation/DBSQL/vcf_config.json
 
  Or for GRCh37:
 
-   perl -pi -e "s|ftp://ftp.ensembl.org/pub/data_files/homo_sapiens/GRCh37|$PWD|" Bio/EnsEMBL/Variation/DBSQL/vcf_config.json 
+   perl -pi -e "s|https://ftp.ensembl.org/pub/data_files/homo_sapiens/GRCh37|$PWD|" Bio/EnsEMBL/Variation/DBSQL/vcf_config.json 
 
 =cut
 

--- a/MPC.pm
+++ b/MPC.pm
@@ -42,7 +42,7 @@ limitations under the License.
  
  The MPC score file is available to download from:
 
- ftp://ftp.broadinstitute.org/pub/ExAC_release/release1/regional_missense_constraint/
+ https://ftp.broadinstitute.org/pub/ExAC_release/release1/regional_missense_constraint/
 
  The data are currently mapped to GRCh37 only. Not all transcripts are included; see
  README in the above directory for exclusion criteria.

--- a/ReferenceQuality.pm
+++ b/ReferenceQuality.pm
@@ -41,8 +41,8 @@ limitations under the License.
  GRCh38:
  
  Download
- ftp://ftp.ncbi.nlm.nih.gov/pub/grc/human/GRC/GRCh38/MISC/annotated_clone_assembly_problems_GCF_000001405.38.gff3
- ftp://ftp.ncbi.nlm.nih.gov/pub/grc/human/GRC/Issue_Mapping/GRCh38.p12_issues.gff3
+ https://ftp.ncbi.nlm.nih.gov/pub/grc/human/GRC/GRCh38/MISC/annotated_clone_assembly_problems_GCF_000001405.38.gff3
+ https://ftp.ncbi.nlm.nih.gov/pub/grc/human/GRC/Issue_Mapping/GRCh38.p12_issues.gff3
  
  cat annotated_clone_assembly_problems_GCF_000001405.38.gff3 GRCh38.p12_issues.gff3 > GRCh38_quality_mergedfile.gff3
  sort -k 1,1 -k 4,4n -k 5,5n GRCh38_quality_mergedfile.gff3 > sorted_GRCh38_quality_mergedfile.gff3
@@ -55,8 +55,8 @@ limitations under the License.
  GRCh37:
  
  Download
- ftp://ftp.ncbi.nlm.nih.gov/pub/grc/human/GRC/GRCh37/MISC/annotated_clone_assembly_problems_GCF_000001405.25.gff3
- ftp://ftp.ncbi.nlm.nih.gov/pub/grc/human/GRC/Issue_Mapping/GRCh37.p13_issues.gff3
+ https://ftp.ncbi.nlm.nih.gov/pub/grc/human/GRC/GRCh37/MISC/annotated_clone_assembly_problems_GCF_000001405.25.gff3
+ https://ftp.ncbi.nlm.nih.gov/pub/grc/human/GRC/Issue_Mapping/GRCh37.p13_issues.gff3
  
  cat annotated_clone_assembly_problems_GCF_000001405.25.gff3 GRCh37.p13_issues.gff3 > GRCh37_quality_mergedfile.gff3
  sort -k 1,1 -k 4,4n -k 5,5n GRCh37_quality_mergedfile.gff3 > sorted_GRCh37_quality_mergedfile.gff3

--- a/StructuralVariantOverlap.pm
+++ b/StructuralVariantOverlap.pm
@@ -57,7 +57,7 @@ limitations under the License.
 Example reference data
 
 1000 Genomes Project:
-ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/phase3/integrated_sv_map/ALL.wgs.mergedSV.v8.20130502.svs.genotypes.vcf.gz
+https://ftp.1000genomes.ebi.ac.uk/vol1/ftp/phase3/integrated_sv_map/ALL.wgs.mergedSV.v8.20130502.svs.genotypes.vcf.gz
 
 gnomAD::
 https://storage.googleapis.com/gnomad-public/papers/2019-sv/gnomad_v2_sv.sites.vcf.gz

--- a/mutfunc.pm
+++ b/mutfunc.pm
@@ -41,7 +41,7 @@ limitations under the License.
  Pre-requisites:
  
  1) The data file. mutfunc SQLite db can be downloaded from - 
- http://ftp.ensembl.org/pub/current_variation/variation/mutfunc/mutfunc_data.db
+ https://ftp.ensembl.org/pub/current_variation/variation/mutfunc/mutfunc_data.db
  
  Options are passed to the plugin as key=value pairs:
 

--- a/pLI.pm
+++ b/pLI.pm
@@ -57,7 +57,7 @@ pLI - Add pLI score to the VEP output
   VEP_plugins GitHub repository. The file contains the fields gene and pLI 
   extracted from the file at 
     
-    ftp://ftp.broadinstitute.org/pub/ExAC_release/release0.3/functional_gene_constraint/
+    https://ftp.broadinstitute.org/pub/ExAC_release/release0.3/functional_gene_constraint/
       fordist_cleaned_exac_r03_march16_z_pli_rec_null_data.txt
 
   From this file, extract gene or transcipt pLI scores:

--- a/plugin_config.txt
+++ b/plugin_config.txt
@@ -1202,7 +1202,7 @@ my $VEP_PLUGIN_CONFIG = {
     },
 
     # AncestralAllele
-    # Requires processed FASTA file from ftp://ftp.ensembl.org/pub/current_fasta/ancestral_alleles/
+    # Requires processed FASTA file from https://ftp.ensembl.org/pub/current_fasta/ancestral_alleles/
     {
       "key" => "AncestralAllele",
       "label" => "Ancestral allele",


### PR DESCRIPTION
As part of migrating ftp links to be accessible over https, I've checked for ftp URLs accross all Ensembl repos.
This PR updates ftp URLs in this repo from http:// and ftp:// protocol to https.
The affected hostnames have been tested to work with https.
Other affected repos are listed in the JIRA ticket.

Webteam JIRA ticket: https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-6632
Sandbox: http://wp-np2-1d.ebi.ac.uk:1680/