### PR TITLE
Add plugin dependencies to build VEP Docker image

### DIFF
--- a/config/cpanfile
+++ b/config/cpanfile
@@ -1,0 +1,2 @@
+recommends 'GD';
+recommends 'Math::CDF';

--- a/config/cpanfile
+++ b/config/cpanfile
@@ -1,2 +1,8 @@
+# Draw plugin
 recommends 'GD';
+
+# Carol plugin
 recommends 'Math::CDF';
+
+# LocalID, mutfunc and SIFT_PolyPhen plugins
+recommends 'DBD::SQLite';

--- a/config/requirements.txt
+++ b/config/requirements.txt
@@ -1,0 +1,2 @@
+mysql
+suds

--- a/config/ubuntu-packages.txt
+++ b/config/ubuntu-packages.txt
@@ -1,8 +1,7 @@
-libgd-dev
-uuid-dev
-
 # Draw plugin: dependency required by Perl package GD
 pkg-config
+libgd-dev
+uuid-dev
 
 # PON_P2 and FATHMM plugins
 python

--- a/config/ubuntu-packages.txt
+++ b/config/ubuntu-packages.txt
@@ -1,0 +1,14 @@
+libgd-dev
+uuid-dev
+
+# Draw plugin: dependency required by Perl package GD
+pkg-config
+
+# PON_P2 and FATHMM plugins
+python
+python-pip
+python-setuptools
+python-dev
+
+# LocalID plugin
+sqlite3


### PR DESCRIPTION
[ENSVAR-4574](https://www.ebi.ac.uk/panda/jira/browse/ENSVAR-4574): Adding VEP plugins to docker image

This PR add three files to list the dependencies needed to run VEP plugins in VEP Docker image (excluding dependencies already installed for **ensembl-vep**):
* **config/cpanfile** for Perl packages
* **config/requirements.txt** for Python modules
* **config/ubuntu-packages.txt** for Ubuntu packages

These files are required for https://github.com/Ensembl/ensembl-vep/pull/1299