### PR TITLE
Deprecate ExAC plugin (109)

### DIFF
--- a/plugin_config.txt
+++ b/plugin_config.txt
@@ -1225,24 +1225,6 @@ my $VEP_PLUGIN_CONFIG = {
     ## FREQUENCY DATA
     #################
 
-    # ExAC
-    {
-      "key" => "ExAC",
-      "label" => "ExAC frequencies",
-      "helptip" => "Reports allele frequencies from the Exome Aggregation Consortium",
-      "available" => 0,
-      "enabled" => 0,
-      "plugin_url" => "https://raw.githubusercontent.com/Ensembl/VEP_plugins/release/109/ExAC.pm",
-      "section" => "Frequency data",
-      "requires_data" => 1,
-      "species" => [
-        "homo_sapiens"
-      ],
-      "params" => [
-        # "/path/to/ExAC.r0.3.sites.vep.vcf.gz"
-      ]
-    },
-
     # gnomADc
     {
       "key" => "gnomADc",
@@ -1774,16 +1756,6 @@ my $VEP_PLUGIN_CONFIG = {
       "available" => 0,
       "enabled" => 0,
       "plugin_url" => "https://raw.githubusercontent.com/Ensembl/VEP_plugins/release/109/CSN.pm",
-    },
-
-    # miRNA
-    {
-      "key" => "miRNA",
-      "label" => "miRNA structure",
-      "helptip" => "Determines where in the secondary structure of a miRNA a variant falls",
-      "available" => 0,
-      "enabled" => 0,
-      "plugin_url" => "https://raw.githubusercontent.com/Ensembl/VEP_plugins/release/109/miRNA.pm",
     }
 
   ]

--- a/plugin_config.txt
+++ b/plugin_config.txt
@@ -1756,6 +1756,16 @@ my $VEP_PLUGIN_CONFIG = {
       "available" => 0,
       "enabled" => 0,
       "plugin_url" => "https://raw.githubusercontent.com/Ensembl/VEP_plugins/release/109/CSN.pm",
+    },
+
+    # miRNA
+    {
+      "key" => "miRNA",
+      "label" => "miRNA structure",
+      "helptip" => "Determines where in the secondary structure of a miRNA a variant falls",
+      "available" => 0,
+      "enabled" => 0,
+      "plugin_url" => "https://raw.githubusercontent.com/Ensembl/VEP_plugins/release/109/miRNA.pm",
     }
 
   ]


### PR DESCRIPTION
[ENSVAR-4536](https://www.ebi.ac.uk/panda/jira/browse/ENSVAR-4536): given that the gnomAD data includes ExAC data (and this is now available through cache), this PR disables ExAC plugin for 109, including:
* No longer being available to install via `INSTALL.pl`
* Remove plugin documentation from [the public list of VEP plugins](https://www.ensembl.org/info/docs/tools/vep/script/vep_plugins.html)

ExAC plugin code will be deprecated later for 110: [ENSVAR-5276](https://www.ebi.ac.uk/panda/jira/browse/ENSVAR-5276)