### PR TITLE
Deprecate miRNA plugin

### DIFF
--- a/plugin_config.txt
+++ b/plugin_config.txt
@@ -1756,16 +1756,6 @@ my $VEP_PLUGIN_CONFIG = {
       "available" => 0,
       "enabled" => 0,
       "plugin_url" => "https://raw.githubusercontent.com/Ensembl/VEP_plugins/release/109/CSN.pm",
-    },
-
-    # miRNA
-    {
-      "key" => "miRNA",
-      "label" => "miRNA structure",
-      "helptip" => "Determines where in the secondary structure of a miRNA a variant falls",
-      "available" => 0,
-      "enabled" => 0,
-      "plugin_url" => "https://raw.githubusercontent.com/Ensembl/VEP_plugins/release/109/miRNA.pm",
     }
 
   ]


### PR DESCRIPTION
[ENSVAR-5227](https://www.ebi.ac.uk/panda/jira/browse/ENSVAR-5227): the miRNA plugin has been superseded by the `--mirna` flag in VEP