### PR TITLE
Update mutfunc plugin FTP url

### DIFF
--- a/mutfunc.pm
+++ b/mutfunc.pm
@@ -41,7 +41,7 @@ limitations under the License.
  Pre-requisites:
 
  1) The data file. mutfunc SQLite db can be downloaded from - 
- http://ftp.ensembl.org/pub/data_files/homo_sapiens/GRCh38/variation_plugins/mutfunc_data.db
+ https://ftp.ensembl.org/pub/data_files/homo_sapiens/GRCh38/variation_plugins/mutfunc_data.db
  
  Options are passed to the plugin as key=value pairs:
 

--- a/mutfunc.pm
+++ b/mutfunc.pm
@@ -41,7 +41,7 @@ limitations under the License.
  Pre-requisites:
 
  1) The data file. mutfunc SQLite db can be downloaded from - 
- https://ftp.ensembl.org/pub/current_variation/variation/mutfunc/mutfunc_data.db
+ http://ftp.ensembl.org/pub/data_files/homo_sapiens/GRCh38/variation_plugins/mutfunc_data.db
  
  Options are passed to the plugin as key=value pairs:
 


### PR DESCRIPTION
In e109 we are changing mutfunc plugin URL, from -
http://ftp.ensembl.org/pub/current_variation/mutfunc/
to -
http://ftp.ensembl.org/pub/data_files/homo_sapiens/GRCh38/variation_plugins/

It is more appropriate to be under plugin directory