### PR TITLE
feat: Allow SV data to CADD

### DIFF
--- a/CADD.pm
+++ b/CADD.pm
@@ -86,6 +86,8 @@ my %INCLUDE_COLUMNS = (
     }
 );
 
+  my $ALT_NUM = 0;
+
 sub new {
   my $class = shift;
   
@@ -174,8 +176,10 @@ sub run {
   if ($bvf->isa("Bio::EnsEMBL::Variation::VariationFeature")){
     $start = $bvf->{start};
     $end = $bvf->{end};
-    $allele = $bvf->alt_alleles->[0];
+    $allele = $bvf->alt_alleles->[$ALT_NUM];
     $ref = $bvf->ref_allele_string;
+
+    ($ALT_NUM + 1) == scalar(@{$bvf->alt_alleles})? $ALT_NUM = 0 : $ALT_NUM += 1;
 
     return {} unless $allele =~ /^[ACGT-]+$/;
 

--- a/CADD.pm
+++ b/CADD.pm
@@ -185,7 +185,7 @@ sub run {
     $ref = "-";
   };
 
-  my @data =  @{$self->get_data($bvf->{chr}, $bvf->{start} - 2, $bvf->{end})};
+  my @data =  @{$self->get_data($bvf->{chr}, $start, $bvf->{end})};
 
   foreach (@data) {
     my $matches = get_matched_variant_alleles(

--- a/CADD.pm
+++ b/CADD.pm
@@ -61,12 +61,26 @@ use Bio::EnsEMBL::Variation::Utils::BaseVepTabixPlugin;
 use base qw(Bio::EnsEMBL::Variation::Utils::BaseVepTabixPlugin);
 
 # List here all columns in headers that should be included
+my %SV_TERMS = (
+    insertion => "INS",
+    deletion => "DEL",
+    duplication => "DUP",
+  );
+
 my %INCLUDE_COLUMNS = (
     "PHRED" => {
       "name" => "CADD_PHRED",
       "description" => 'PHRED-like scaled CADD score'
     },
     "RawScore" => {
+      "name" => "CADD_RAW",
+      "description" => 'Raw CADD score'
+    },
+    "CADD-SV_PHRED-score" => {
+      "name" => "CADD_PHRED",
+      "description" => 'PHRED-like scaled CADD score'
+    },
+    "CADD-SV_Raw-score" => {
       "name" => "CADD_RAW",
       "description" => 'Raw CADD score'
     }
@@ -135,6 +149,10 @@ sub new {
   return $self;
 }
 
+sub variant_feature_types {
+    return ['VariationFeature', 'StructuralVariationFeature'];
+}
+
 sub feature_types {
   return ['Feature','Intergenic'];
 }
@@ -148,22 +166,34 @@ sub get_header_info {
 sub run {
   my ($self, $tva) = @_;
   
-  my $vf = $tva->variation_feature;
-  
-  # get allele
-  my $allele = $tva->variation_feature_seq;
-  
-  return {} unless $allele =~ /^[ACGT-]+$/;
+  my $bvf = $tva->base_variation_feature;
 
-  my @data =  @{$self->get_data($vf->{chr}, $vf->{start} - 2, $vf->{end})};
+  my ($start, $allele, $ref, $so_term);
+
+  # get allele
+  if ($bvf->isa("Bio::EnsEMBL::Variation::VariationFeature")){
+    $start = $bvf->{start};
+    $allele = $bvf->alt_alleles->[0];
+    $ref = $bvf->ref_allele_string;
+
+    return {} unless $allele =~ /^[ACGT-]+$/;
+
+  } else {
+    $start = $bvf->{start} - 1;
+    $so_term = $bvf->class_SO_term();
+    $allele = $SV_TERMS{$so_term};
+    $ref = "-";
+  };
+
+  my @data =  @{$self->get_data($bvf->{chr}, $bvf->{start} - 2, $bvf->{end})};
 
   foreach (@data) {
     my $matches = get_matched_variant_alleles(
       {
-        ref    => $vf->ref_allele_string,
+        ref    => $ref,
         alts   => [$allele],
-        pos    => $vf->{start},
-        strand => $vf->strand
+        pos    => $start,
+        strand => $bvf->strand
       },
       {
        ref  => $_->{ref},
@@ -185,9 +215,9 @@ sub parse_data {
   my %data = map {$headers[$_] => $values[$_]} (0..(@headers - 1));
 
   my $c = $data{"#Chrom"};
-  my $s = $data{"Pos"};
-  my $ref = $data{"Ref"};
-  my $alt = $data{"Alt"};
+  my $s = $data{"Pos"} || $data{"Start"};
+  my $ref = $data{"Ref"} || "-";
+  my $alt = $data{"Alt"} || $data{"Type"};
 
   # Conditional result
   my %result = ();
@@ -197,7 +227,7 @@ sub parse_data {
   }
 
   # do VCF-like coord adjustment for mismatched subs
-  my $end = ($s + length($ref)) - 1;
+  my $end = $data{"End"} || ($s + length($ref)) - 1;
   if(length($alt) != length($ref)) {
     my $first_ref = substr($ref, 0, 1);
     my $first_alt = substr($alt, 0, 1);

--- a/CADD.pm
+++ b/CADD.pm
@@ -168,11 +168,12 @@ sub run {
   
   my $bvf = $tva->base_variation_feature;
 
-  my ($start, $allele, $ref, $so_term);
+  my ($start, $end, $allele, $ref, $so_term);
 
   # get allele
   if ($bvf->isa("Bio::EnsEMBL::Variation::VariationFeature")){
     $start = $bvf->{start};
+    $end = $bvf->{start};
     $allele = $bvf->alt_alleles->[0];
     $ref = $bvf->ref_allele_string;
 
@@ -180,14 +181,18 @@ sub run {
 
   } else {
     $start = $bvf->{start} - 1;
+    $end = $bvf->{end};
     $so_term = $bvf->class_SO_term();
     $allele = $SV_TERMS{$so_term};
     $ref = "-";
   };
 
-  my @data =  @{$self->get_data($bvf->{chr}, $start, $bvf->{end})};
+  my @data =  @{$self->get_data($bvf->{chr}, $start, $end)};
 
   foreach (@data) {
+
+    next if $end != $_->{end};
+
     my $matches = get_matched_variant_alleles(
       {
         ref    => $ref,

--- a/CADD.pm
+++ b/CADD.pm
@@ -173,7 +173,7 @@ sub run {
   # get allele
   if ($bvf->isa("Bio::EnsEMBL::Variation::VariationFeature")){
     $start = $bvf->{start};
-    $end = $bvf->{start};
+    $end = $bvf->{end};
     $allele = $bvf->alt_alleles->[0];
     $ref = $bvf->ref_allele_string;
 
@@ -187,7 +187,7 @@ sub run {
     $ref = "-";
   };
 
-  my @data =  @{$self->get_data($bvf->{chr}, $start, $end)};
+  my @data =  @{$self->get_data($bvf->{chr}, $start - 2, $end)};
 
   foreach (@data) {
 

--- a/CADD.pm
+++ b/CADD.pm
@@ -179,7 +179,11 @@ sub run {
     $allele = $bvf->alt_alleles->[$ALT_NUM];
     $ref = $bvf->ref_allele_string;
 
-    ($ALT_NUM + 1) == scalar(@{$bvf->alt_alleles})? $ALT_NUM = 0 : $ALT_NUM += 1;
+    if (($ALT_NUM + 1) == scalar(@{$bvf->alt_alleles})) {
+      $ALT_NUM = 0;
+    } else {
+      $ALT_NUM += 1;
+    };
 
     return {} unless $allele =~ /^[ACGT-]+$/;
 
@@ -194,8 +198,6 @@ sub run {
   my @data =  @{$self->get_data($bvf->{chr}, $start - 2, $end)};
 
   foreach (@data) {
-
-    next if $end != $_->{end};
 
     my $matches = get_matched_variant_alleles(
       {


### PR DESCRIPTION
## Description

Now we also have CADD SV data, this PR adjusts CADD original code to allow new details from SV input.

## Technical

1) CADD SV have only 3 terms (INS, DEL and DUP);
2) `variation_feature_seq` was altered to `base_variation_feature`;
3) A variant_feature_type was added `StructuralVariationFeature`;
4) Match was tested with short variants and SVs.
5) Since `get_matched_variant_alleles` does not receive `end` as input, a conditional to skip non-matching `end` was added.

## Test

Files: https://kircherlab.bihealth.org/download/CADD-SV/v1.1/

1) Test with short variants reference file;
2) Test with SV reference;
3) Test with both.