### PR TITLE
Improve dbNSFP plugin

### DIFF
--- a/dbNSFP.pm
+++ b/dbNSFP.pm
@@ -472,7 +472,7 @@ sub get_dbNSFP_file_header {
     # parse data line to identify transcript-specific fields
     else {
       next unless /\;/;
-      die "ERROR: No headers found before data" unless defined($self->{headers});
+      die "ERROR: No headers found before data\n" unless defined($self->{headers});
       my $row_data = $self->parse_data($_);
       my @transcript_specific_fields;
       for my $key(keys %$row_data) {
@@ -498,7 +498,7 @@ sub add_replacement_logic {
       chomp;
       next if /^colname/;
       my ($colname, $from, $to) = split/\s+/;
-      die ("ERROR: replacement logic file requires 3 values separated by whitespace in this format: colname from to.")
+      die ("ERROR: replacement logic file requires 3 values separated by whitespace in this format: colname from to.\n")
         if(!($colname && $from && $to));
       push @{$self->{replacement}->{$colname}->{from}}, $from;
       push @{$self->{replacement}->{$colname}->{to}}, $to;
@@ -553,7 +553,7 @@ sub get_named_params {
   }
 
   if ($self->{transcript_match} && !defined($self->{transcript_specific_fields})) {
-    die("ERROR: transcript_match parameter specified but transcript-specific field detection failed");
+    die("ERROR: transcript_match parameter specified but transcript-specific field detection failed\n");
   }
 }
 

--- a/dbNSFP.pm
+++ b/dbNSFP.pm
@@ -222,7 +222,7 @@ sub new {
     unless defined($self->{cols}) && scalar keys %{$self->{cols}};
   
   warn "WARNING: the following columns were not found in file header: ",
-       join(",", @invalid), "\n";
+       join(",", @invalid), "\n" if (@invalid);
   return $self;
 }
 

--- a/plugin_config.txt
+++ b/plugin_config.txt
@@ -684,6 +684,14 @@ my $VEP_PLUGIN_CONFIG = {
             "Geuvadis_eQTL_target_gene"
           ],
         },
+        {
+          "name" => "dbNSFP_transcript_match",
+          "label" => "Transcript match",
+          "helptip" => "By default, some fields contain values for all Ensembl transcripts. Select this to return values only for the matched Ensembl transcript.",
+          "value" => "transcript_match=1",
+          "type" => "checkbox",
+          "style" => "height:150px"
+        }
       ]
     },
 

--- a/plugin_config.txt
+++ b/plugin_config.txt
@@ -687,7 +687,7 @@ my $VEP_PLUGIN_CONFIG = {
         {
           "name" => "dbNSFP_transcript_match",
           "label" => "Transcript match",
-          "helptip" => "By default, some fields contain values for all Ensembl transcripts. Select this to return values only for the matched Ensembl transcript.",
+          "helptip" => "By default, some dbNSFP fields contain values for all Ensembl transcripts. Select this to only return values for the matched Ensembl transcript.",
           "value" => "transcript_match=1",
           "type" => "checkbox",
           "style" => "height:150px"


### PR DESCRIPTION
[ENSVAR-5414](https://www.ebi.ac.uk/panda/jira/browse/ENSVAR-5414), based on Ensembl/ensembl-rest#544

When using the dbNSFP plugin, the plugin dies if any of the fields is not available in the dbNSFP file. In the command-line, VEP still returns an output with a warning explaining which fields are invalid.

However, if using dbNSFP with an invalid field in REST, VEP returns its output with no dbNSFP fields. Given that REST does not display any warning messages, the user has no idea whether the plugin didn't return anything because that variant is not found in dbNSFP or if there is an invalid field. Related with **documentation update in REST**: Ensembl/ensembl-rest#581.

## Changes

The following changes apply to the dbNSFP plugin in general and are not restricted to only REST.

- Print all fields even if invalid: invalid fields will display `invalid_field`
    - Would another value instead of `invalid_field` be more adequate here? Like `invalid_dbNSFP_field`?
    - Should this only be returned when running in REST?
- Allow to use named parameters in any location
    - Currently, we can only put the option `consequence=all` as the first parameter and `transcript_match=1` and `protein_match=1` after the filename(s) and before the dbNSFP fields
- Add `transcript_match` option to web VEP

## Testing

Test dbNSFP plugin in VEP (command-line):
* Example variant: `18  23873048   rs867018739  C  T`
* Use an invalid field between valid fields
    * Example: `MVP_score,random_stuff,Ensembl_transcriptid`
* Use argument `transcript_match=1` in between any field
    * Example: `MVP_score,random_stuff,transcript_match=1,Ensembl_transcriptid`
* Test `transcript_match` option in web VEP: http://wp-np2-11.ebi.ac.uk:6070/Homo_sapiens/Tools/VEP 