### PR TITLE
Update plugins to not use $tva->variation_feature_seq (part 1)

### DIFF
--- a/CAPICE.pm
+++ b/CAPICE.pm
@@ -99,9 +99,7 @@ sub run {
   my $vf = $tva->variation_feature;
   
   # get allele
-  my $allele = $tva->variation_feature_seq;
-  
-  return {} unless $allele =~ /^[ACGT-]+$/;
+  my $allele = $tva->base_variation_feature->alt_alleles;
 
   my @data = @{$self->get_data($vf->{chr}, $vf->{start} - 2, $vf->{end})};
 
@@ -109,7 +107,7 @@ sub run {
     my $matches = get_matched_variant_alleles(
       {
         ref    => $vf->ref_allele_string,
-        alts   => [$allele],
+        alts   => $allele,
         pos    => $vf->{start},
         strand => $vf->strand
       },

--- a/ClinPred.pm
+++ b/ClinPred.pm
@@ -90,12 +90,14 @@ sub run{
   return {} unless grep {$INCLUDE_SO{$_->SO_term}} @{$tva->get_all_OverlapConsequences};
   
   my $vf = $tva->variation_feature;
-  my $allele = $tva->variation_feature_seq;
-  return {} unless $allele =~ /^[ACGT]$/;
-  
+  my $allele = $tva->base_variation_feature->alt_alleles;
 
   my ($vf_start, $vf_end) = ($vf->{start}, $vf->{end});
   ($vf_start, $vf_end) = ($vf_end, $vf_start) if ($vf_start > $vf_end);
+
+  foreach $a (@{$allele}) {
+    
+  }
 
   my ($res) = grep{
     $_->{alt} eq $allele &&

--- a/Conservation.pm
+++ b/Conservation.pm
@@ -179,7 +179,6 @@ sub run {
   #Parse and strip out the expected info from the BigWig file
   my $parser = Bio::EnsEMBL::IO::Parser::BigWig->open($filename);
   my $vf = $tva->variation_feature;
-  my $allele = $tva->variation_feature_seq;
   unless($parser){
     warn ("No BigWig file found for plugin Conservation \n"); 
     return {};

--- a/EVE.pm
+++ b/EVE.pm
@@ -140,10 +140,8 @@ sub run {
   return {} unless grep {$_->SO_term eq 'missense_variant'} @{$tva->get_all_OverlapConsequences};
 
   # get allele
-  my $alt_allele = $tva->variation_feature_seq;
+  my $alt_alleles = $tva->base_variation_feature->alt_alleles;
   my $ref_allele = $vf->ref_allele_string;
-
-  return {} unless $alt_allele =~ /^[ACGT-]+$/;
 
   my @data = @{
     $self->get_data(
@@ -160,7 +158,7 @@ sub run {
     my $matches = get_matched_variant_alleles(
       {
         ref    => $ref_allele,
-        alts   => [$alt_allele],
+        alts   => $alt_alleles,
         pos    => $vf->{start},
         strand => $vf->strand
       },

--- a/FATHMM_MKL.pm
+++ b/FATHMM_MKL.pm
@@ -83,17 +83,17 @@ sub run {
   return {} unless $vf->{start} == $vf->{end};
   
   # get allele, reverse comp if needed
-  my $allele = $tva->variation_feature_seq;
-  reverse_comp(\$allele) if $vf->{strand} < 0;
-  
-  return {} unless $allele =~ /^[ACGT]$/;
+  my $alleles = $tva->base_variation_feature->alt_alleles;
   
   # adjust coords, file is BED-like (but not 0-indexed, go figure...)
   my ($s, $e) = ($vf->{start}, $vf->{end} + 1);
   
   foreach my $data(@{$self->get_data($vf->{chr}, $s, $e)}) {
-    if($data->{start} == $s && $allele eq $data->{alt}) {
-      return $data->{result};
+    foreach $allele (@{$alleles}) {
+      reverse_comp(\$allele) if $vf->{strand} < 0;
+      if($data->{start} == $s && $allele eq $data->{alt}) {
+        return $data->{result};
+      }
     }
   }
 
@@ -125,4 +125,3 @@ sub get_end {
 }
 
 1;
-

--- a/GWAS.pm
+++ b/GWAS.pm
@@ -191,7 +191,7 @@ sub run {
     my $matches = get_matched_variant_alleles(
       {
         ref    => $vf->ref_allele_string,
-        alts   => [$tva->variation_feature_seq],
+        alts   => $tva->base_variation_feature->alt_alleles,
         pos    => $vf->{"start"},
         strand => $vf->strand
       },

--- a/GeneSplicer.pm
+++ b/GeneSplicer.pm
@@ -182,12 +182,9 @@ sub run {
   return {} unless $ref_seq =~ /^[ACGT]+$/;
 
   # create alt seq
-  my $alt_allele = $tva->variation_feature_seq;
+  my $alt_alleles = $tva->base_variation_feature->alt_alleles;
   $alt_allele =~ s/\-//g;
   my $alt_seq = $up_seq.$alt_allele.$down_seq;
-
-
-  return {} unless $alt_seq =~ /^[ACGT]+$/;
 
   # reverse comp if strands differ
   if($tva->transcript->strand != $vf->strand) {
@@ -366,4 +363,3 @@ sub map_ss_coords {
 }
 
 1;
-

--- a/MPC.pm
+++ b/MPC.pm
@@ -94,7 +94,7 @@ sub run {
   return {} unless $vf->{start} == $vf->{end};
   
   # get allele, reverse comp if needed
-  my $allele = $tva->variation_feature_seq;
+  my $allele = $tva->base_variation_feature->alt_alleles;
   reverse_comp(\$allele) if $vf->{strand} < 0;
   
   return {} unless $allele =~ /^[ACGT]$/;

--- a/PON_P2.pm
+++ b/PON_P2.pm
@@ -74,8 +74,6 @@ sub run {
 	## If not snp return
 	return {} unless $vf->{start} == $vf->{end};
 
-	## get allele, reverse comp if needed
-	my $allele = $tva -> variation_feature_seq;
 	my $Variation = $tva -> hgvs_genomic;
 	my ($Chr, $Pos, $Alt) = (split /:g.|>/, $Variation)[0,1,2];
 	my $Position = substr $Pos, 0, -1;

--- a/PrimateAI.pm
+++ b/PrimateAI.pm
@@ -144,9 +144,7 @@ sub run {
   my ($self, $tva) = @_;
 
   my $vf = $tva->variation_feature;
-  my $allele = $tva->variation_feature_seq;
-
-  return {} unless $allele =~ /^[ACGT]$/;
+  my $allele = $tva->base_variation_feature->alt_alleles;
 
   #Get the start and end coordinates, and ensure they are the right way round (i.e. start < end).
   my $vf_start = $vf->{start};

--- a/REVEL.pm
+++ b/REVEL.pm
@@ -134,7 +134,6 @@ sub run {
   return {} unless grep {$_->SO_term eq 'missense_variant'} @{$tva->get_all_OverlapConsequences};
 
   my $vf = $tva->variation_feature;
-  my $allele = $tva->variation_feature_seq;
   my $tr_stable_id = $tva->transcript->stable_id;
   
   my @data =  @{$self->get_data($vf->{chr}, $vf->{start}, $vf->{end})};

--- a/ReferenceQuality.pm
+++ b/ReferenceQuality.pm
@@ -109,7 +109,6 @@ sub run {
   my ($self, $tva) = @_;
     
   my $vf = $tva->variation_feature;
-  my $allele = $tva->variation_feature_seq;
   my $chr = $vf->{chr};
 
   my $chr_syn;


### PR DESCRIPTION
The object `$tva->variation_feature_seq` has the shifted alt allele which is not the alt allele we want to use in the plugins (see [this PR](https://github.com/Ensembl/ensembl-variation/pull/962)).
This update fetches the alt alleles from `$tva->base_variation_feature->alt_alleles`.

[ENSVAR-5501](https://www.ebi.ac.uk/panda/jira/browse/ENSVAR-5501)
