### PR TITLE
Remove deprecated miRNA plugin from plugin config

### DIFF
--- a/plugin_config.txt
+++ b/plugin_config.txt
@@ -1748,16 +1748,6 @@ my $VEP_PLUGIN_CONFIG = {
       "available" => 0,
       "enabled" => 0,
       "plugin_url" => "https://raw.githubusercontent.com/Ensembl/VEP_plugins/release/110/CSN.pm",
-    },
-
-    # miRNA
-    {
-      "key" => "miRNA",
-      "label" => "miRNA structure",
-      "helptip" => "Determines where in the secondary structure of a miRNA a variant falls",
-      "available" => 0,
-      "enabled" => 0,
-      "plugin_url" => "https://raw.githubusercontent.com/Ensembl/VEP_plugins/release/110/miRNA.pm",
     }
 
   ]


### PR DESCRIPTION
[ENSVAR-5227](https://www.ebi.ac.uk/panda/jira/browse/ENSVAR-5227): Deprecated miRNA plugin should not be configured in plugin config

Redoing https://github.com/Ensembl/VEP_plugins/pull/555 that was reverted somehow