### PR TITLE
Add option to REVEL

### DIFF
--- a/REVEL.pm
+++ b/REVEL.pm
@@ -162,7 +162,7 @@ sub run {
       }
     }
     else {
-      return $_->{result} if ($_->{altaa} eq $tva->peptide);
+      return $_->{result} if ($_->{altaa} eq $tva->peptide && $_->{alt} eq $allele);
     }
   }
   return {};


### PR DESCRIPTION
By default, if the REVEL file contains transcript ids the plugin is going to return scores only if the transcripts match. 
This PR adds the option to not match by transcript id.
It also checks if alt alleles match.

Test case: https://github.com/Ensembl/ensembl-vep/issues/1369 