### PR TITLE
Fix plugin PON_P2

### DIFF
--- a/PON_P2.pm
+++ b/PON_P2.pm
@@ -79,12 +79,12 @@ sub run {
   my $alt_allele = $tva->base_variation_feature->alt_alleles;
 
   ## Check for single nucleotide substitution
-  return {} unless $Ref =~ /^[ACGT]$/;
-  return {} unless $Alt =~ /^[ACGT]$/;
+  return {} unless $ref_allele =~ /^[ACGT]$/;
+  return {} unless $alt_allele->[0] =~ /^[ACGT]$/;
 
   my $command = $self->{command};
   my $Hg = $self->{Hg};
-  my $V = $chr."_".$start."_".$ref_allele."_".$alt_allele[0];
+  my $V = $chr."_".$start."_".$ref_allele."_".$alt_allele->[0];
 
   ## Call pon-p2 python script here
   my $ponp2Res = `python $command $V $Hg` or return {};

--- a/PON_P2.pm
+++ b/PON_P2.pm
@@ -27,7 +27,6 @@ package PON_P2;
 use strict;
 use warnings;
 
-
 use Bio::EnsEMBL::Utils::Sequence qw(reverse_comp);
 use Bio::EnsEMBL::Variation::Utils::BaseVepTabixPlugin;
 
@@ -35,71 +34,71 @@ use base qw(Bio::EnsEMBL::Variation::Utils::BaseVepPlugin);
 
 
 sub feature_types {
-	return ['Transcript'];
+  return ['Transcript'];
 }
 
 
 sub get_header_info {
-	return {
-		PON_P2 => "PON-P2 prediction and score for amino acid substitutions"
-	};
+  return {
+    PON_P2 => "PON-P2 prediction and score for amino acid substitutions"
+  };
 }
 
 
 sub new {
-	my $class = shift;
-	my $self = $class->SUPER::new(@_);
-	# get parameters
-	my $command = $self->params->[0];
-	my $Hg = $self->params->[1];
-	die 'ERROR: Path to python script not specified! Specify path to python script e.g. --plugin PON_P2,/path/to/python/client/for/ponp2.py,[hg37/hg38]\n' unless defined($command);
-	die 'ERROR: Reference genome not specified! Specify the reference genome after the path to python file e.g. --plugin PON_P2,/path/to/python/client/for/ponp2.py,[hg37/hg38]\n' unless defined($command);
-	die "ERROR: Wrong reference genome specified! It should be either 'hg37' or 'hg38'\n" unless ($Hg ~~ ["hg37","hg38"]);
-	die 'ERROR: Incorrect path to ponp2.py\n' unless -e $command;
-	$self->{command} = $command;
-	$self->{Hg} = $Hg;
-	return $self;
+  my $class = shift;
+  my $self = $class->SUPER::new(@_);
+  # get parameters
+  my $command = $self->params->[0];
+  my $Hg = $self->params->[1];
+  die 'ERROR: Path to python script not specified! Specify path to python script e.g. --plugin PON_P2,/path/to/python/client/for/ponp2.py,[hg37/hg38]\n' unless defined($command);
+  die 'ERROR: Reference genome not specified! Specify the reference genome after the path to python file e.g. --plugin PON_P2,/path/to/python/client/for/ponp2.py,[hg37/hg38]\n' unless defined($command);
+  die "ERROR: Wrong reference genome specified! It should be either 'hg37' or 'hg38'\n" unless ($Hg ~~ ["hg37","hg38"]);
+  die 'ERROR: Incorrect path to ponp2.py\n' unless -e $command;
+  $self->{command} = $command;
+  $self->{Hg} = $Hg;
+  return $self;
 }
 
 
 sub run {
-	my ($self, $tva) = @_;
+  my ($self, $tva) = @_;
 
-	# only for missense variants
-	return {} unless grep {$_->SO_term eq 'missense_variant'} @{$tva->get_all_OverlapConsequences};
+  # only for missense variants
+  return {} unless grep {$_->SO_term eq 'missense_variant'} @{$tva->get_all_OverlapConsequences};
 
-	## Now get the variation features
-	my $vf=$tva -> variation_feature;
+  ## Now get the variation features
+  my $vf = $tva->variation_feature;
 
-	## If not snp return
-	return {} unless $vf->{start} == $vf->{end};
+  ## If not snp return
+  return {} unless $vf->{start} == $vf->{end};
 
-	my $Variation = $tva -> hgvs_genomic;
-	my ($Chr, $Pos, $Alt) = (split /:g.|>/, $Variation)[0,1,2];
-	my $Position = substr $Pos, 0, -1;
-	my $Ref = substr $Pos, -1;
-	
-	## Check for single nucleotide substitution
-	return {} unless $Ref =~ /^[ACGT]$/;
-	return {} unless $Alt =~ /^[ACGT]$/;
+  my $chr = $vf->{chr};
+  my $start = $vf->{start};
+  my $ref_allele = $vf->ref_allele_string;
+  my $alt_allele = $tva->base_variation_feature->alt_alleles;
 
-	my $command = $self -> {command};
-	my $Hg = $self -> {Hg};
-	my $V = $Chr."_".$Position."_".$Ref."_".$Alt;;
+  ## Check for single nucleotide substitution
+  return {} unless $Ref =~ /^[ACGT]$/;
+  return {} unless $Alt =~ /^[ACGT]$/;
 
-	## Call pon-p2 python script here
-	my $ponp2Res = `python $command $V $Hg` or return {};
-	$ponp2Res =~ s/\R//g;
+  my $command = $self->{command};
+  my $Hg = $self->{Hg};
+  my $V = $chr."_".$start."_".$ref_allele."_".$alt_allele[0];
 
-	my ($pred, $prob) =split /\t/, $ponp2Res;
+  ## Call pon-p2 python script here
+  my $ponp2Res = `python $command $V $Hg` or return {};
+  $ponp2Res =~ s/\R//g;
 
-	## Can PON-P2 predict?
-	return {} if $pred eq "cannot";
+  my ($pred, $prob) =split /\t/, $ponp2Res;
 
-	## Return predictions
-	return $pred && $prob ? {
-		PON_P2 => "$pred($prob)",
-	} : {};
+  ## Can PON-P2 predict?
+  return {} if $pred eq "cannot";
+
+  ## Return predictions
+  return $pred && $prob ? {
+    PON_P2 => "$pred($prob)",
+  } : {};
 }
 
 1;

--- a/PON_P2.pm
+++ b/PON_P2.pm
@@ -80,25 +80,27 @@ sub run {
 
   ## Check for single nucleotide substitution
   return {} unless $ref_allele =~ /^[ACGT]$/;
-  return {} unless $alt_allele->[0] =~ /^[ACGT]$/;
 
-  my $command = $self->{command};
-  my $Hg = $self->{Hg};
-  my $V = $chr."_".$start."_".$ref_allele."_".$alt_allele->[0];
+  foreach my $alt (@{$alt_allele}) {
+    my $command = $self->{command};
+    my $Hg = $self->{Hg};
+    my $V = $chr."_".$start."_".$ref_allele."_".$alt;
 
-  ## Call pon-p2 python script here
-  my $ponp2Res = `python $command $V $Hg` or return {};
-  $ponp2Res =~ s/\R//g;
+    ## Call pon-p2 python script here
+    my $ponp2Res = `python $command $V $Hg` or return {};
+    $ponp2Res =~ s/\R//g;
 
-  my ($pred, $prob) =split /\t/, $ponp2Res;
+    my ($pred, $prob) =split /\t/, $ponp2Res;
 
-  ## Can PON-P2 predict?
-  return {} if $pred eq "cannot";
+    ## Can PON-P2 predict?
+    return {} if $pred eq "cannot";
 
-  ## Return predictions
-  return $pred && $prob ? {
-    PON_P2 => "$pred($prob)",
-  } : {};
+    ## Return predictions
+    return $pred && $prob ? {
+      PON_P2 => "$pred($prob)",
+    } : {};
+
+  }
 }
 
 1;

--- a/PON_P2.pm
+++ b/PON_P2.pm
@@ -28,10 +28,10 @@ Mauno Vihinen <mauno.vihinen@med.lu.se>
      python suds). The python file can be downloaded from http://structure.bmc.lu.se/PON-P2/vep.html/
      and the complete path to this file must be supplied while using this plugin.
  
- 2) To fetch the predictions from a file containing pre-calculated predictions please use
- the following option:
+ 2) To fetch the predictions from a file containing pre-calculated predictions for somatic variations 
+ please use the following option:
  
-  file:           text file with pre-calculated predictions downloaded from
+  file:           COSMIC text file with pre-calculated predictions downloaded from
                   http://structure.bmc.lu.se/PON-P2/cancer30.html/
    
    The following steps are necessary before using the file:

--- a/PON_P2.pm
+++ b/PON_P2.pm
@@ -15,9 +15,37 @@ Mauno Vihinen <mauno.vihinen@med.lu.se>
  Protein Structure and Bioinformatics Group at Lund University and is available at 
  http://structure.bmc.lu.se/PON-P2/.
  
- To run this plugin, you will require a python script and its dependencies (Python,
- python suds). The python file can be downloaded from http://structure.bmc.lu.se/PON-P2/vep.html/
- and the complete path to this file must be supplied while using this plugin.
+ There are two ways to run the plugin:
+ 
+ 1) To compute the predictions from the PON-P2 API please use the following options:
+
+  Option 1:       python script 'ponp2.py'*
+  Option 2:       the reference genome. Acceptable values are: hg37, hg38
+ 
+   --plugin PON_P2,/path/to/python/script/ponp2.py,hg37
+   
+   * To run this mode, you will require a python script and its dependencies (Python,
+     python suds). The python file can be downloaded from http://structure.bmc.lu.se/PON-P2/vep.html/
+     and the complete path to this file must be supplied while using this plugin.
+ 
+ 2) To fetch the predictions from a file containing pre-calculated predictions please use
+ the following option:
+ 
+  file:           text file with pre-calculated predictions downloaded from
+                  http://structure.bmc.lu.se/PON-P2/cancer30.html/
+   
+   The following steps are necessary before using the file:
+   (head -n 1 COSMIC.txt && tail -n +2 COSMIC.txt | sort -t $'\t' -k1,1 -k2,2n) > cosmic_sorted.txt
+   sed -i 's/Chromosome/#Chromosome/' cosmic_sorted.txt
+   bgzip cosmic_sorted.txt
+   tabix -s 1 -b 2 -e 2 cosmic_sorted.txt.gz
+   
+   --plugin PON_P2,file=path/to/cosmic_sorted.txt.gz
+   
+   If you use this data, please cite the following publication
+   Niroula, A., Vihinen, M. Harmful somatic amino acid substitutions affect key pathways in cancers.
+   BMC Med Genomics 8, 53 (2015). https://doi.org/10.1186/s12920-015-0125-x
+ 
 
 =cut
 
@@ -29,9 +57,9 @@ use warnings;
 
 use Bio::EnsEMBL::Utils::Sequence qw(reverse_comp);
 use Bio::EnsEMBL::Variation::Utils::BaseVepTabixPlugin;
-
+use Bio::EnsEMBL::Variation::Utils::Sequence qw(get_matched_variant_alleles);
+use base qw(Bio::EnsEMBL::Variation::Utils::BaseVepTabixPlugin);
 use base qw(Bio::EnsEMBL::Variation::Utils::BaseVepPlugin);
-
 
 sub feature_types {
   return ['Transcript'];
@@ -48,15 +76,30 @@ sub get_header_info {
 sub new {
   my $class = shift;
   my $self = $class->SUPER::new(@_);
+
   # get parameters
   my $command = $self->params->[0];
   my $Hg = $self->params->[1];
-  die 'ERROR: Path to python script not specified! Specify path to python script e.g. --plugin PON_P2,/path/to/python/client/for/ponp2.py,[hg37/hg38]\n' unless defined($command);
-  die 'ERROR: Reference genome not specified! Specify the reference genome after the path to python file e.g. --plugin PON_P2,/path/to/python/client/for/ponp2.py,[hg37/hg38]\n' unless defined($command);
-  die "ERROR: Wrong reference genome specified! It should be either 'hg37' or 'hg38'\n" unless ($Hg ~~ ["hg37","hg38"]);
-  die 'ERROR: Incorrect path to ponp2.py\n' unless -e $command;
-  $self->{command} = $command;
-  $self->{Hg} = $Hg;
+
+  my $from_file;
+  # Check if first option is the file
+  if($command && $command =~ /file=/) {
+    my $param_hash = $self->params_to_hash();
+    $from_file = $param_hash->{file};
+    die "\nERROR: No PON_P2 file specified\nTry using 'file=path/to/file.txt.gz'\n" unless -e $from_file;
+    $self->add_file($from_file);
+    $self->{from_file} = $from_file;
+  }
+  
+  if(!$from_file) {
+    die 'ERROR: Path to python script not specified! Specify path to python script e.g. --plugin PON_P2,/path/to/python/client/for/ponp2.py,[hg37/hg38]\n' unless defined($command);
+    die 'ERROR: Reference genome not specified! Specify the reference genome after the path to python file e.g. --plugin PON_P2,/path/to/python/client/for/ponp2.py,[hg37/hg38]\n' unless defined($command);
+    die "ERROR: Wrong reference genome specified! It should be either 'hg37' or 'hg38'\n" unless ($Hg ~~ ["hg37","hg38"]);
+    die 'ERROR: Incorrect path to ponp2.py\n' unless -e $command;
+    $self->{command} = $command;
+    $self->{Hg} = $Hg;
+  }
+  
   return $self;
 }
 
@@ -75,32 +118,94 @@ sub run {
 
   my $chr = $vf->{chr};
   my $start = $vf->{start};
+  my $end = $vf->{end};
   my $ref_allele = $vf->ref_allele_string;
   my $alt_allele = $tva->base_variation_feature->alt_alleles;
 
   ## Check for single nucleotide substitution
   return {} unless $ref_allele =~ /^[ACGT]$/;
 
-  foreach my $alt (@{$alt_allele}) {
-    my $command = $self->{command};
-    my $Hg = $self->{Hg};
-    my $V = $chr."_".$start."_".$ref_allele."_".$alt;
+  if($self->{from_file}) {
+    my @data = @{ $self->get_data($chr, $start, $end) };
+    return {} unless(@data);
 
-    ## Call pon-p2 python script here
-    my $ponp2Res = `python $command $V $Hg` or return {};
-    $ponp2Res =~ s/\R//g;
+    foreach (@data) {
 
-    my ($pred, $prob) =split /\t/, $ponp2Res;
+      my $matches = get_matched_variant_alleles(
+        {
+          ref    => $ref_allele,
+          alts   => $alt_allele,
+          pos    => $start,
+          strand => $vf->strand
+        },
+        {
+           ref  => $_->{ref},
+           alts => [$_->{alt}],
+           pos  => $_->{start},
+        }
+      );
 
-    ## Can PON-P2 predict?
-    return {} if $pred eq "cannot";
+      if (@{$matches}) {
+        my $tv = $tva->transcript_variation;
+        my $peptide_start = defined($tv->translation_start) ? $tv->translation_start : undef;
+        my @vf_aa = split '/', $tva->pep_allele_string;
 
-    ## Return predictions
-    return $pred && $prob ? {
-      PON_P2 => "$pred($prob)",
-    } : {};
-
+        if ($_->{aa} eq $vf_aa[0].$peptide_start.$vf_aa[1]) {
+          my $pred = $_->{pon_p2_pred};
+          my $class = $_->{pon_p2_class};
+          return {
+            PON_P2 => "$pred($class)"
+          };
+        }
+        return {};
+      }
+    }
   }
+  else {
+    foreach my $alt (@{$alt_allele}) {
+      my $command = $self->{command};
+      my $Hg = $self->{Hg};
+      my $V = $chr."_".$start."_".$ref_allele."_".$alt;
+
+      ## Call pon-p2 python script here
+      my $ponp2Res = `python $command $V $Hg` or return {};
+      $ponp2Res =~ s/\R//g;
+
+      my ($pred, $prob) =split /\t/, $ponp2Res;
+
+      ## Can PON-P2 predict?
+      return {} if $pred eq "cannot";
+
+      ## Return predictions
+      return $pred && $prob ? {
+        PON_P2 => "$pred($prob)",
+      } : {};
+    }
+  }
+}
+
+sub parse_data {
+  my ($self, $line) = @_;
+
+  my @all_data = split /\t/, $line;
+
+  return {
+      start => $all_data[1],
+      end => $all_data[2],
+      ref => $all_data[3],
+      alt => $all_data[4],
+      aa => $all_data[6],
+      pon_p2_pred => $all_data[7],
+      pon_p2_class => $all_data[9]
+  };
+}
+
+sub get_start {
+  return $_[1]->{start};
+}
+
+sub get_end {
+  return $_[1]->{end};
 }
 
 1;


### PR DESCRIPTION
Issue reported here https://github.com/Ensembl/VEP_plugins/issues/590 

The plugin doesn't need to fetch the chr, pos and alleles from the hgvs_genomic. It can directly fetch them from objects `$vf` and `$tva`.

Please see the ticket [ENSVAR-5546](https://www.ebi.ac.uk/panda/jira/browse/ENSVAR-5546) for details on how to test.
