### PR TITLE
Fix phenotype data subset

### DIFF
--- a/Phenotypes.pm
+++ b/Phenotypes.pm
@@ -304,8 +304,9 @@ sub run {
     my @result_data = ();
 
     foreach my $tmp_data(@{$data}) {
-      # delete not selected columns
-      map {delete $tmp_data->{$_}} grep {!defined($cols{$_})} keys %$tmp_data;
+      # subset phenotype data columns
+      my %tmp = map { $_ => $tmp_data->{$_} } keys %cols;
+      $tmp_data = \%tmp;
 
       if (!$output_format{'json'}) {
         # replace link characters with _


### PR DESCRIPTION
[ENSVAR-5620](https://www.ebi.ac.uk/panda/jira/browse/ENSVAR-5620)

## Motivation

When running VEP with the Phenotypes plugin for **chr16_11001363_C/T** by itself, the variant returns the expected associated phenotypes: `BARE_LYMPHOCYTE_SYNDROME__TYPE_II|MIM_morbid|ENSG00000179583,Immunodeficiency_by_defective_expression_of_MHC_class_II|Orphanet|ENSG00000179583`.

However, if we run with multiple variants, some phenotypes (including for this variant) are omitted. It seems there is a bug for certain variants: when removing elements from a `$tmp_data` variable to hold phenotype information, multiple warnings are presented and phenotypes are discarded in some cases. I simply decided to create the same variable in an alternative way.

## Testing

Run VEP with Phenotypes plugin using the VCF attached in JIRA. It should return the phenotype for variant chr16_11001363_C/T (example of TXT output):
```
chr16_11001363_C/T	chr16:11001363	T	ENSG00000179583	ENST00000324288	Transcript	stop_gained	2147	2014	672	Q/*	Caa/Taa	IMPACT=HIGH;STRAND=1;PHENOTYPES=BARE_LYMPHOCYTE_SYNDROME__TYPE_II|MIM_morbid|ENSG00000179583,Immunodeficiency_by_defective_expression_of_MHC_class_II|Orphanet|ENSG00000179583
chr16_11001363_C/T	chr16:11001363	T	ENSG00000179583	ENST00000381835	Transcript	intron_variant	-	-	-	-	-	IMPACT=MODIFIER;STRAND=1;PHENOTYPES=BARE_LYMPHOCYTE_SYNDROME__TYPE_II|MIM_morbid|ENSG00000179583,Immunodeficiency_by_defective_expression_of_MHC_class_II|Orphanet|ENSG00000179583
chr16_11001363_C/T	chr16:11001363	T	ENSG00000179583	ENST00000537380	Transcript	intron_variant,non_coding_transcript_variant	-	IMPACT=MODIFIER;STRAND=1;PHENOTYPES=BARE_LYMPHOCYTE_SYNDROME__TYPE_II|MIM_morbid|ENSG00000179583,Immunodeficiency_by_defective_expression_of_MHC_class_II|Orphanet|ENSG00000179583
chr16_11001363_C/T	chr16:11001363	T	ENSG00000179583	ENST00000570546	Transcript	non_coding_transcript_exon_variant	2135	-	IMPACT=MODIFIER;STRAND=1;PHENOTYPES=BARE_LYMPHOCYTE_SYNDROME__TYPE_II|MIM_morbid|ENSG00000179583,Immunodeficiency_by_defective_expression_of_MHC_class_II|Orphanet|ENSG00000179583
chr16_11001363_C/T	chr16:11001363	T	ENSG00000179583	ENST00000571186	Transcript	downstream_gene_variant	-	-	-	-	IMPACT=MODIFIER;DISTANCE=4784;STRAND=1;PHENOTYPES=BARE_LYMPHOCYTE_SYNDROME__TYPE_II|MIM_morbid|ENSG00000179583,Immunodeficiency_by_defective_expression_of_MHC_class_II|Orphanet|ENSG00000179583
chr16_11001363_C/T	chr16:11001363	T	ENSG00000179583	ENST00000573309	Transcript	non_coding_transcript_exon_variant	1985	-	IMPACT=MODIFIER;STRAND=1;PHENOTYPES=BARE_LYMPHOCYTE_SYNDROME__TYPE_II|MIM_morbid|ENSG00000179583,Immunodeficiency_by_defective_expression_of_MHC_class_II|Orphanet|ENSG00000179583
```