### PR TITLE
Plugin changes to support multiple calls

### DIFF
--- a/CADD.pm
+++ b/CADD.pm
@@ -29,8 +29,8 @@ limitations under the License.
 
  mv CADD.pm ~/.vep/Plugins
  ./vep -i variations.vcf --plugin CADD,/FULL_PATH_TO_CADD_FILE/whole_genome_SNVs.tsv.gz,/FULL_PATH_TO_CADD_FILE/InDels.tsv.gz
- ./vep -i variations.vcf --plugin CADD,whole_genome=/FULL_PATH_TO_CADD_FILE/whole_genome_SNVs.tsv.gz,indels=/FULL_PATH_TO_CADD_FILE/InDels.tsv.gz
- 
+ ./vep -i variations.vcf --plugin CADD,snv=/FULL_PATH_TO_CADD_FILE/whole_genome_SNVs.tsv.gz,indels=/FULL_PATH_TO_CADD_FILE/InDels.tsv.gz
+
 =head1 DESCRIPTION
 
  A VEP plugin that retrieves CADD scores for variants from one or more
@@ -108,7 +108,7 @@ sub new {
   if (!keys %$params) {
     @files = @{$self->params};  
   } else {
-    for my $key (keys %{$params}){
+    for my $key ( keys %{$params}){
       push @files, $params->{$key}
     }
   }

--- a/CADD.pm
+++ b/CADD.pm
@@ -100,8 +100,6 @@ sub new {
   $self->expand_left(0);
   $self->expand_right(0);
 
-  #$self->get_user_params();
-
   my $params = $self->params_to_hash();
   my @files;
   # Check files in arguments
@@ -109,7 +107,7 @@ sub new {
     @files = @{$self->params};  
   } else {
     for my $key ( keys %{$params}){
-      push @files, $params->{$key}
+      push @files, $params->{$key};
     }
   }
 

--- a/CADD.pm
+++ b/CADD.pm
@@ -28,7 +28,6 @@ limitations under the License.
 =head1 SYNOPSIS
 
  mv CADD.pm ~/.vep/Plugins
- ./vep -i variations.vcf --plugin CADD,/FULL_PATH_TO_CADD_FILE/whole_genome_SNVs.tsv.gz,/FULL_PATH_TO_CADD_FILE/InDels.tsv.gz
  ./vep -i variations.vcf --plugin CADD,snv=/FULL_PATH_TO_CADD_FILE/whole_genome_SNVs.tsv.gz,indels=/FULL_PATH_TO_CADD_FILE/InDels.tsv.gz
 
 =head1 DESCRIPTION
@@ -99,6 +98,7 @@ sub new {
 
   $self->expand_left(0);
   $self->expand_right(0);
+  $self->get_user_params();
 
   my $params = $self->params_to_hash();
   my @files;

--- a/CADD.pm
+++ b/CADD.pm
@@ -29,7 +29,8 @@ limitations under the License.
 
  mv CADD.pm ~/.vep/Plugins
  ./vep -i variations.vcf --plugin CADD,/FULL_PATH_TO_CADD_FILE/whole_genome_SNVs.tsv.gz,/FULL_PATH_TO_CADD_FILE/InDels.tsv.gz
-
+ ./vep -i variations.vcf --plugin CADD,whole_genome=/FULL_PATH_TO_CADD_FILE/whole_genome_SNVs.tsv.gz,indels=/FULL_PATH_TO_CADD_FILE/InDels.tsv.gz
+ 
 =head1 DESCRIPTION
 
  A VEP plugin that retrieves CADD scores for variants from one or more
@@ -99,19 +100,28 @@ sub new {
   $self->expand_left(0);
   $self->expand_right(0);
 
-  $self->get_user_params();
+  #$self->get_user_params();
 
+  my $params = $self->params_to_hash();
+  my @files;
   # Check files in arguments
-  my @params = @{$self->params};
+  if (!keys %$params) {
+    @files = @{$self->params};  
+  } else {
+    for my $key (keys %{$params}){
+      push @files, $params->{$key}
+    }
+  }
 
-  die "\nERROR: No CADD files specified\nTip: Add a file after command, example:\nvep ... --plugin CADD,/FULL_PATH_TO_CADD_FILE/whole_genome_SNVs.tsv.gz\n" unless @params > 0;
-  $self->add_file($_) for @params;
+  die "\nERROR: No CADD files specified\nTip: Add a file after command, example:\nvep ... --plugin CADD,/FULL_PATH_TO_CADD_FILE/whole_genome_SNVs.tsv.gz\n" unless @files > 0;
+  $self->add_file($_) for @files;
 
   my $assembly = $self->{config}->{assembly};
 
   $self->{header} = ();
 
-  foreach my $file (@params) {
+
+  foreach my $file (@files) {
     open IN, "tabix -f -h ".$file." 1:1-1 |";
 
     my @lines = <IN>;

--- a/CAPICE.pm
+++ b/CAPICE.pm
@@ -34,6 +34,7 @@ limitations under the License.
  # - capice_v1.0_build37_snvs.tsv.gz
  # - capice_v1.0_build37_snvs.tsv.gz.tbi
  ./vep -i variations.vcf --plugin CAPICE,/FULL_PATH_TO_CAPICE_FILE/capice_v1.0_build37_snvs.tsv.gz,/FULL_PATH_TO_CAPICE_FILE/capice_v1.0_build37_indels.tsv.gz
+ ./vep -i variations.vcf --plugin CAPICE,snv=/FULL_PATH_TO_CAPICE_FILE/capice_v1.0_build37_snvs.tsv.gz,indels=/FULL_PATH_TO_CAPICE_FILE/capice_v1.0_build37_indels.tsv.gz
  ./filter_vep -i variant_effect_output.txt --filter "CAPICE_SCORE >= 0.02"
 
 =head1 DESCRIPTION
@@ -73,12 +74,22 @@ sub new {
 
   $self->expand_left(0);
   $self->expand_right(0);
-  $self->get_user_params();
+  #$self->get_user_params();
   
   # Check files in arguments
-  my @params = @{$self->params};
-  die "ERROR: No CAPICE files specified\n" unless @params > 0;
-  $self->add_file($_) for @params;
+  my @files; 
+  my $params = $self->params_to_hash();
+
+  if (!keys %$params){
+    @files = @{$self->params};
+  } else {
+    for my $key (keys %{$params}) {
+      push @files, $params->{$key};
+    }
+  }
+
+  die "ERROR: No CAPICE files specified\n" unless @files > 0;
+  $self->add_file($_) for @files;
 
   return $self;
 }

--- a/CAPICE.pm
+++ b/CAPICE.pm
@@ -33,7 +33,6 @@ limitations under the License.
  # - capice_v1.0_build37_indels.tsv.gz.tbi
  # - capice_v1.0_build37_snvs.tsv.gz
  # - capice_v1.0_build37_snvs.tsv.gz.tbi
- ./vep -i variations.vcf --plugin CAPICE,/FULL_PATH_TO_CAPICE_FILE/capice_v1.0_build37_snvs.tsv.gz,/FULL_PATH_TO_CAPICE_FILE/capice_v1.0_build37_indels.tsv.gz
  ./vep -i variations.vcf --plugin CAPICE,snv=/FULL_PATH_TO_CAPICE_FILE/capice_v1.0_build37_snvs.tsv.gz,indels=/FULL_PATH_TO_CAPICE_FILE/capice_v1.0_build37_indels.tsv.gz
  ./filter_vep -i variant_effect_output.txt --filter "CAPICE_SCORE >= 0.02"
 
@@ -74,6 +73,7 @@ sub new {
 
   $self->expand_left(0);
   $self->expand_right(0);
+  $self->get_user_params();
   
   # Check files in arguments
   my @files; 

--- a/CAPICE.pm
+++ b/CAPICE.pm
@@ -74,7 +74,6 @@ sub new {
 
   $self->expand_left(0);
   $self->expand_right(0);
-  #$self->get_user_params();
   
   # Check files in arguments
   my @files; 

--- a/ClinPred.pm
+++ b/ClinPred.pm
@@ -45,7 +45,7 @@ limitations under the License.
  The tabix utility must be installed in your path to use this plugin.
  Check https://github.com/samtools/htslib.git for instructions.
 
---plugin ClinPred,file=
+--plugin ClinPred,file=ClinPred_tabbed.tsv.gz
 --plugin ClinPred,ClinPred_tabbed.tsv.gz
 =cut
 

--- a/ClinPred.pm
+++ b/ClinPred.pm
@@ -20,7 +20,6 @@ limitations under the License.
 =head1 SYNOPSIS
  
  mv ClinPred.pm ~/.vep/Plugins
- ./vep -i variations.vcf --plugin ClinPred,/path/to/ClinPred/data.txt.gz
  ./vep -i variations.vcf --plugin ClinPred,file=ClinPred_tabbed.tsv.gz
 
 
@@ -66,6 +65,7 @@ sub new {
 
   $self->expand_left(0);
   $self->expand_right(0);
+  $self->get_user_params();
   
   my $params = $self->params_to_hash();
   my $file;

--- a/ClinPred.pm
+++ b/ClinPred.pm
@@ -21,6 +21,8 @@ limitations under the License.
  
  mv ClinPred.pm ~/.vep/Plugins
  ./vep -i variations.vcf --plugin ClinPred,/path/to/ClinPred/data.txt.gz
+ ./vep -i variations.vcf --plugin ClinPred,file=ClinPred_tabbed.tsv.gz
+
 
 =head1 DESCRIPTION
  This is a plugin for the Ensembl Variant Effect Predictor (VEP) that adds pre-calculated scores from ClinPred.
@@ -45,8 +47,7 @@ limitations under the License.
  The tabix utility must be installed in your path to use this plugin.
  Check https://github.com/samtools/htslib.git for instructions.
 
---plugin ClinPred,file=ClinPred_tabbed.tsv.gz
---plugin ClinPred,ClinPred_tabbed.tsv.gz
+
 =cut
 
 package ClinPred;

--- a/ClinPred.pm
+++ b/ClinPred.pm
@@ -45,6 +45,8 @@ limitations under the License.
  The tabix utility must be installed in your path to use this plugin.
  Check https://github.com/samtools/htslib.git for instructions.
 
+--plugin ClinPred,file=
+--plugin ClinPred,ClinPred_tabbed.tsv.gz
 =cut
 
 package ClinPred;
@@ -64,7 +66,15 @@ sub new {
   $self->expand_left(0);
   $self->expand_right(0);
   
-  my $file = $self->params->[0];
+  my $params = $self->params_to_hash();
+  my $file;
+  if (!keys %$params) {
+    $file = $self->params->[0];
+    $params->{file} = $file;
+  } else {
+    $file = $params->{file};
+  } 
+
   $self->add_file($file);
   
   my $assembly = $self->{config}->{assembly};

--- a/Mastermind.pm
+++ b/Mastermind.pm
@@ -141,7 +141,8 @@ sub new {
     $self->{only_mmid3} = $params->{var_iden} if (defined ($params->{var_iden}));
     $self->{return_url} = $params->{url} if (defined ($params->{url}) );
   }
- 
+  
+  die "ERROR: Mastermind file not specified! Path to Mastermind file needs to be specified \n" if (!defined ($file));
 
   $self->add_file($file); 
 

--- a/Mastermind.pm
+++ b/Mastermind.pm
@@ -28,10 +28,10 @@ limitations under the License.
 =head1 SYNOPSIS
 
  mv Mastermind.pm ~/.vep/Plugins
- ./vep -i variations.vcf --plugin Mastermind,/path/to/data.vcf.gz
- ./vep -i variations.vcf --plugin Mastermind,/path/to/data.vcf.gz,1
- ./vep -i variations.vcf --plugin Mastermind,/path/to/data.vcf.gz,0,1
- ./vep -i variations.vcf --plugin Mastermind,/path/to/data.vcf.gz,0,0,1
+ ./vep -i variations.vcf --plugin Mastermind,file=/path/to/data.vcf.gz
+ ./vep -i variations.vcf --plugin Mastermind,file=/path/to/data.vcf.gz,mutations=1
+ ./vep -i variations.vcf --plugin Mastermind,file=/path/to/data.vcf.gz,mutations=0,var_iden=1
+ ./vep -i variations.vcf --plugin Mastermind,file=/path/to/data.vcf.gz,mutations=0,var_iden=0,url=1
 
 =head1 DESCRIPTION
 

--- a/Mastermind.pm
+++ b/Mastermind.pm
@@ -130,11 +130,10 @@ sub new {
   my @key_params;
   my $file;
   if (!%{$params}) {
-    @key_params = @{$self->params};
-    $file = $key_params[0];
-    $self->{mutation_off} = $key_params[1] if ( defined($key_params[1]) ) ;
-    $self->{only_mmid3} = $key_params[2]  if ( defined($key_params[2]) ) ;
-    $self->{return_url} = $key_params[3] if( defined($key_params[3]) ) ;
+    $file = $self->params->[0];
+    $self->{mutation_off} = $self->params->[1] if ( defined($self->params->[1]) ) ;
+    $self->{only_mmid3} = $self->params->[2]  if ( defined($self->params->[2]) ) ;
+    $self->{return_url} = $self->params->[3] if( defined($self->params->[3]) ) ;
   } else {
     $file = $params->{file};
     $self->{mutation_off} = $params->{mutations} if (defined($params->{mutations}));
@@ -142,8 +141,6 @@ sub new {
     $self->{return_url} = $params->{url} if (defined ($params->{url}) );
   }
   
-  die "ERROR: Mastermind file not specified! Path to Mastermind file needs to be specified \n" if (!defined ($file));
-
   $self->add_file($file); 
 
   return $self;

--- a/Mastermind.pm
+++ b/Mastermind.pm
@@ -132,9 +132,9 @@ sub new {
   if (!%{$params}) {
     @key_params = @{$self->params};
     $file = $key_params[0];
-    $self->{mutation_off} = $key_params[1] if ( defined($self->params->[1]) ) ;
-    $self->{only_mmid3} = $key_params[2]  if ( defined($self->params->[2]) ) ;
-    $self->{return_url} = $key_params[3] if( defined($self->params->[3]) ) ;
+    $self->{mutation_off} = $key_params[1] if ( defined($key_params[1]) ) ;
+    $self->{only_mmid3} = $key_params[2]  if ( defined($key_params[2]) ) ;
+    $self->{return_url} = $key_params[3] if( defined($key_params[3]) ) ;
   } else {
     $file = $params->{file};
     $self->{mutation_off} = $params->{mutations} if (defined($params->{mutations}));

--- a/Mastermind.pm
+++ b/Mastermind.pm
@@ -125,37 +125,25 @@ sub new {
   $self->expand_left(0);
   $self->expand_right(0);
 
-  #$self->get_user_params();
   my $params = $self->params_to_hash();
-  
+
   my @key_params;
   my $file;
-  if (!keys %$params){
+  if (!%{$params}) {
     @key_params = @{$self->params};
     $file = $key_params[0];
+    $self->{mutation_off} = $key_params[1] if ( defined($self->params->[1]) ) ;
+    $self->{only_mmid3} = $key_params[2]  if ( defined($self->params->[2]) ) ;
+    $self->{return_url} = $key_params[3] if( defined($self->params->[3]) ) ;
   } else {
     $file = $params->{file};
-    for my $key (keys %{$params}) {
-      push @key_params, $params->{$key};
-    }
+    $self->{mutation_off} = $params->{mutations} if (defined($params->{mutations}));
+    $self->{only_mmid3} = $params->{var_iden} if (defined ($params->{var_iden}));
+    $self->{return_url} = $params->{url} if (defined ($params->{url}) );
   }
-  
-  use Data::Dumper;
-  print(Dumper(@key_params));
+ 
 
   $self->add_file($file); 
-
-  if(defined($key_params[1]) || defined($params->{mutations}) ) {
-    $self->{mutation_off} = $key_params[1];
-  }
-
-  if(defined($key_params[2]) || defined($params->{var_iden})) {
-    $self->{only_mmid3} = $key_params[2];
-  }
-
-  if(defined($key_params[3]) || defined($params->{url})) {
-    $self->{return_url} = $key_params[3];
-  }
 
   return $self;
 }

--- a/Mastermind.pm
+++ b/Mastermind.pm
@@ -87,19 +87,15 @@ limitations under the License.
   
  
  The plugin can then be run as default:
- ./vep -i variations.vcf --plugin Mastermind,/path/to/mastermind_cited_variants_reference-XXXX.XX.XX.GRChXX-vcf.gz
  ./vep -i variations.vcf --plugin Mastermind,file=/path/to/mastermind_cited_variants_reference-XXXX.XX.XX.GRChXX-vcf.gz
 
  or with an option to not filter by mutations (first flag): 
- ./vep -i variations.vcf --plugin Mastermind,/path/to/mastermind_cited_variants_reference-XXXX.XX.XX.GRChXX-vcf.gz,1 
  ./vep -i variations.vcf --plugin Mastermind,/path/to/mastermind_cited_variants_reference-XXXX.XX.XX.GRChXX-vcf.gz,mutations=1 
 
  or with an option to only return 'MMID3' e.g. the Mastermind variant identifier as gene:key (second flag):
- ./vep -i variations.vcf --plugin Mastermind,/path/to/mastermind_cited_variants_reference-XXXX.XX.XX.GRChXX-vcf.gz,0,1
  ./vep -i variations.vcf --plugin Mastermind,/path/to/mastermind_cited_variants_reference-XXXX.XX.XX.GRChXX-vcf.gz,mutations=0,var_iden=1
 
  or with an option to also return the Mastermind URL (third flag):
- ./vep -i variations.vcf --plugin Mastermind,/path/to/mastermind_cited_variants_reference-XXXX.XX.XX.GRChXX-vcf.gz,0,0,1
  ./vep -i variations.vcf --plugin Mastermind,/path/to/mastermind_cited_variants_reference-XXXX.XX.XX.GRChXX-vcf.gz,mutations=0,var_iden=0,url=1
 
  Note: when running VEP in offline mode Mastermind requires a fasta file (--fasta)
@@ -124,6 +120,7 @@ sub new {
 
   $self->expand_left(0);
   $self->expand_right(0);
+  $self->get_user_params();
 
   my $params = $self->params_to_hash();
 

--- a/Mastermind.pm
+++ b/Mastermind.pm
@@ -93,7 +93,7 @@ limitations under the License.
 ./vep -i variations.vcf --plugin Mastermind,file=/path/to/mastermind_cited_variants_reference-XXXX.XX.XX.GRChXX-vcf.gz,mutations=1 
 
  or with an option to only return 'MMID3' e.g. the Mastermind variant identifier as gene:key (second flag):
- ./vep -i variations.vcf --plugin Mastermind,/path/to/mastermind_cited_variants_reference-XXXX.XX.XX.GRChXX-vcf.gz,mutations=0,var_iden=1
+ ./vep -i variations.vcf --plugin Mastermind,file=/path/to/mastermind_cited_variants_reference-XXXX.XX.XX.GRChXX-vcf.gz,mutations=0,var_iden=1
 
  or with an option to also return the Mastermind URL (third flag):
 ./vep -i variations.vcf --plugin Mastermind,file=/path/to/mastermind_cited_variants_reference-XXXX.XX.XX.GRChXX-vcf.gz,mutations=0,var_iden=0,url=1

--- a/Mastermind.pm
+++ b/Mastermind.pm
@@ -96,7 +96,7 @@ limitations under the License.
  ./vep -i variations.vcf --plugin Mastermind,/path/to/mastermind_cited_variants_reference-XXXX.XX.XX.GRChXX-vcf.gz,mutations=0,var_iden=1
 
  or with an option to also return the Mastermind URL (third flag):
- ./vep -i variations.vcf --plugin Mastermind,/path/to/mastermind_cited_variants_reference-XXXX.XX.XX.GRChXX-vcf.gz,mutations=0,var_iden=0,url=1
+./vep -i variations.vcf --plugin Mastermind,file=/path/to/mastermind_cited_variants_reference-XXXX.XX.XX.GRChXX-vcf.gz,mutations=0,var_iden=0,url=1
 
  Note: when running VEP in offline mode Mastermind requires a fasta file (--fasta)
 

--- a/Mastermind.pm
+++ b/Mastermind.pm
@@ -90,7 +90,7 @@ limitations under the License.
  ./vep -i variations.vcf --plugin Mastermind,file=/path/to/mastermind_cited_variants_reference-XXXX.XX.XX.GRChXX-vcf.gz
 
  or with an option to not filter by mutations (first flag): 
- ./vep -i variations.vcf --plugin Mastermind,/path/to/mastermind_cited_variants_reference-XXXX.XX.XX.GRChXX-vcf.gz,mutations=1 
+./vep -i variations.vcf --plugin Mastermind,file=/path/to/mastermind_cited_variants_reference-XXXX.XX.XX.GRChXX-vcf.gz,mutations=1 
 
  or with an option to only return 'MMID3' e.g. the Mastermind variant identifier as gene:key (second flag):
  ./vep -i variations.vcf --plugin Mastermind,/path/to/mastermind_cited_variants_reference-XXXX.XX.XX.GRChXX-vcf.gz,mutations=0,var_iden=1

--- a/Mastermind.pm
+++ b/Mastermind.pm
@@ -88,15 +88,19 @@ limitations under the License.
  
  The plugin can then be run as default:
  ./vep -i variations.vcf --plugin Mastermind,/path/to/mastermind_cited_variants_reference-XXXX.XX.XX.GRChXX-vcf.gz
+ ./vep -i variations.vcf --plugin Mastermind,file=/path/to/mastermind_cited_variants_reference-XXXX.XX.XX.GRChXX-vcf.gz
 
  or with an option to not filter by mutations (first flag): 
  ./vep -i variations.vcf --plugin Mastermind,/path/to/mastermind_cited_variants_reference-XXXX.XX.XX.GRChXX-vcf.gz,1 
+ ./vep -i variations.vcf --plugin Mastermind,/path/to/mastermind_cited_variants_reference-XXXX.XX.XX.GRChXX-vcf.gz,mutations=1 
 
  or with an option to only return 'MMID3' e.g. the Mastermind variant identifier as gene:key (second flag):
  ./vep -i variations.vcf --plugin Mastermind,/path/to/mastermind_cited_variants_reference-XXXX.XX.XX.GRChXX-vcf.gz,0,1
+ ./vep -i variations.vcf --plugin Mastermind,/path/to/mastermind_cited_variants_reference-XXXX.XX.XX.GRChXX-vcf.gz,mutations=0,var_iden=1
 
  or with an option to also return the Mastermind URL (third flag):
  ./vep -i variations.vcf --plugin Mastermind,/path/to/mastermind_cited_variants_reference-XXXX.XX.XX.GRChXX-vcf.gz,0,0,1
+ ./vep -i variations.vcf --plugin Mastermind,/path/to/mastermind_cited_variants_reference-XXXX.XX.XX.GRChXX-vcf.gz,mutations=0,var_iden=0,url=1
 
  Note: when running VEP in offline mode Mastermind requires a fasta file (--fasta)
 
@@ -121,20 +125,36 @@ sub new {
   $self->expand_left(0);
   $self->expand_right(0);
 
-  $self->get_user_params();
-  my $file = $self->params->[0];
-  $self->add_file($file);
+  #$self->get_user_params();
+  my $params = $self->params_to_hash();
+  
+  my @key_params;
+  my $file;
+  if (!keys %$params){
+    @key_params = @{$self->params};
+    $file = $key_params[0];
+  } else {
+    $file = $params->{file};
+    for my $key (keys %{$params}) {
+      push @key_params, $params->{$key};
+    }
+  }
+  
+  use Data::Dumper;
+  print(Dumper(@key_params));
 
-  if(defined($self->params->[1])) {
-    $self->{mutation_off} = $self->params->[1];
+  $self->add_file($file); 
+
+  if(defined($key_params[1]) || defined($params->{mutations}) ) {
+    $self->{mutation_off} = $key_params[1];
   }
 
-  if(defined($self->params->[2])) {
-    $self->{only_mmid3} = $self->params->[2];
+  if(defined($key_params[2]) || defined($params->{var_iden})) {
+    $self->{only_mmid3} = $key_params[2];
   }
 
-  if(defined($self->params->[3])) {
-    $self->{return_url} = $self->params->[3];
+  if(defined($key_params[3]) || defined($params->{url})) {
+    $self->{return_url} = $key_params[3];
   }
 
   return $self;

--- a/PON_P2.pm
+++ b/PON_P2.pm
@@ -23,6 +23,7 @@ Mauno Vihinen <mauno.vihinen@med.lu.se>
   Option 2:       the reference genome. Acceptable values are: hg37, hg38
  
    --plugin PON_P2,/path/to/python/script/ponp2.py,hg37
+   --plugin PON_P2,pyscript=/path/to/python/script/ponp2.py,hg=hg37
    
    * To run this mode, you will require a python script and its dependencies (Python,
      python suds). The python file can be downloaded from http://structure.bmc.lu.se/PON-P2/vep.html/

--- a/PON_P2.pm
+++ b/PON_P2.pm
@@ -76,17 +76,48 @@ sub new {
   my $self = $class->SUPER::new(@_);
 
   # get parameters
-  my $command = $self->params->[0];
-  my $Hg = $self->params->[1];
+  #my $command = $self->params->[0];
+  #my $Hg = $self->params->[1];
+  my $params = $self->params_to_hash();
+  my $pyscript;
+  my $hg;
+  my $from_file;
 
+  if (!%{$params}) {
+    my @key_params = @{$self->params};
+    $pyscript = $key_params[0];
+    $hg = $key_params[1];
+  } else {
+    if (exists $params->{"file"}) {
+      $from_file = $params->{file};
+      die "\nERROR: No PON_P2 file specified\nTry using 'file=path/to/file.txt.gz'\n" unless -e $from_file;
+      $self->add_file($from_file);
+      $self->{from_file} = $from_file;
+    } else {
+      $pyscript = $params->{pyscript} if (defined ($params->{pyscript})); 
+      $hg = $params->{hg} if (defined($params->{hg}))
+    }
+  }
+
+  if(!$from_file) {
+    die 'ERROR: Path to python script not specified! Specify path to python script e.g. --plugin PON_P2,/path/to/python/client/for/ponp2.py,[hg37/hg38]\n' unless defined($pyscript);
+    die 'ERROR: Reference genome not specified! Specify the reference genome after the path to python file e.g. --plugin PON_P2,/path/to/python/client/for/ponp2.py,[hg37/hg38]\n' unless defined($hg);
+    die "ERROR: Wrong reference genome specified! It should be either 'hg37' or 'hg38'\n" unless ($hg ~~ ["hg37","hg38"]);
+    die 'ERROR: Incorrect path to ponp2.py\n' unless -e $pyscript;
+  }
+
+  $self->{command} = $pyscript;
+  $self->{Hg} = $hg;
+
+
+=head1
   my $from_file;
   # Check if first option is the file
   if($command && $command =~ /file=/) {
     my $param_hash = $self->params_to_hash();
     $from_file = $param_hash->{file};
     die "\nERROR: No PON_P2 file specified\nTry using 'file=path/to/file.txt.gz'\n" unless -e $from_file;
-    $self->add_file($from_file);
-    $self->{from_file} = $from_file;
+
   }
   
   if(!$from_file) {
@@ -97,7 +128,7 @@ sub new {
     $self->{command} = $command;
     $self->{Hg} = $Hg;
   }
-  
+=cut
   return $self;
 }
 

--- a/PON_P2.pm
+++ b/PON_P2.pm
@@ -85,9 +85,8 @@ sub new {
   my $from_file;
 
   if (!%{$params}) {
-    my @key_params = @{$self->params};
-    $pyscript = $key_params[0];
-    $hg = $key_params[1];
+    $pyscript = $self->params->[0];
+    $hg = $self->params->[1];
   } else {
     if (exists $params->{"file"}) {
       $from_file = $params->{file};

--- a/PON_P2.pm
+++ b/PON_P2.pm
@@ -22,7 +22,6 @@ Mauno Vihinen <mauno.vihinen@med.lu.se>
   Option 1:       python script 'ponp2.py'*
   Option 2:       the reference genome. Acceptable values are: hg37, hg38
  
-   --plugin PON_P2,/path/to/python/script/ponp2.py,hg37
    --plugin PON_P2,pyscript=/path/to/python/script/ponp2.py,hg=hg37
    
    * To run this mode, you will require a python script and its dependencies (Python,

--- a/PON_P2.pm
+++ b/PON_P2.pm
@@ -110,26 +110,6 @@ sub new {
   $self->{command} = $pyscript;
   $self->{Hg} = $hg;
 
-
-=head1
-  my $from_file;
-  # Check if first option is the file
-  if($command && $command =~ /file=/) {
-    my $param_hash = $self->params_to_hash();
-    $from_file = $param_hash->{file};
-    die "\nERROR: No PON_P2 file specified\nTry using 'file=path/to/file.txt.gz'\n" unless -e $from_file;
-
-  }
-  
-  if(!$from_file) {
-    die 'ERROR: Path to python script not specified! Specify path to python script e.g. --plugin PON_P2,/path/to/python/client/for/ponp2.py,[hg37/hg38]\n' unless defined($command);
-    die 'ERROR: Reference genome not specified! Specify the reference genome after the path to python file e.g. --plugin PON_P2,/path/to/python/client/for/ponp2.py,[hg37/hg38]\n' unless defined($command);
-    die "ERROR: Wrong reference genome specified! It should be either 'hg37' or 'hg38'\n" unless ($Hg ~~ ["hg37","hg38"]);
-    die 'ERROR: Incorrect path to ponp2.py\n' unless -e $command;
-    $self->{command} = $command;
-    $self->{Hg} = $Hg;
-  }
-=cut
   return $self;
 }
 

--- a/PON_P2.pm
+++ b/PON_P2.pm
@@ -3,7 +3,7 @@
  
 =head1 SYNOPSIS
  mv PON_P2.pm ~/.vep/Plugins
- ./vep -i variations.vcf --plugin PON_P2,/path/to/python/script/ponp2.py,hg37
+ ./vep -i variations.vcf --plugin PON_P2,pyscript=/path/to/python/script/ponp2.py,hg=hg37
  
 =head1 CONTACT
 Abhishek Niroula <abhishek.niroula@med.lu.se>

--- a/PON_P2.pm
+++ b/PON_P2.pm
@@ -19,32 +19,32 @@ Mauno Vihinen <mauno.vihinen@med.lu.se>
  
  1) To compute the predictions from the PON-P2 API please use the following options:
 
-  Option 1:       python script 'ponp2.py'*
-  Option 2:       the reference genome. Acceptable values are: hg37, hg38
+   Option 1:       python script 'ponp2.py'*
+   Option 2:       the reference genome. Acceptable values are: hg37, hg38
  
-   --plugin PON_P2,pyscript=/path/to/python/script/ponp2.py,hg=hg37
+    --plugin PON_P2,pyscript=/path/to/python/script/ponp2.py,hg=hg37
    
-   * To run this mode, you will require a python script and its dependencies (Python,
-     python suds). The python file can be downloaded from http://structure.bmc.lu.se/PON-P2/vep.html/
-     and the complete path to this file must be supplied while using this plugin.
+    * To run this mode, you will require a python script and its dependencies (Python,
+    python suds). The python file can be downloaded from http://structure.bmc.lu.se/PON-P2/vep.html/
+    and the complete path to this file must be supplied while using this plugin.
  
  2) To fetch the predictions from a file containing pre-calculated predictions for somatic variations 
  please use the following option (only available for GRCh37):
  
-  file:           COSMIC text file with pre-calculated predictions downloaded from
+   file:           COSMIC text file with pre-calculated predictions downloaded from
                   http://structure.bmc.lu.se/PON-P2/cancer30.html/
    
-   The following steps are necessary before using the file:
-   (head -n 1 COSMIC.txt && tail -n +2 COSMIC.txt | sort -t $'\t' -k1,1 -k2,2n) > cosmic_sorted.txt
-   sed -i 's/Chromosome/#Chromosome/' cosmic_sorted.txt
-   bgzip cosmic_sorted.txt
-   tabix -s 1 -b 2 -e 2 cosmic_sorted.txt.gz
+     The following steps are necessary before using the file:
+      (head -n 1 COSMIC.txt && tail -n +2 COSMIC.txt | sort -t $'\t' -k1,1 -k2,2n) > cosmic_sorted.txt
+      sed -i 's/Chromosome/#Chromosome/' cosmic_sorted.txt
+      bgzip cosmic_sorted.txt
+      tabix -s 1 -b 2 -e 2 cosmic_sorted.txt.gz
    
-   --plugin PON_P2,file=path/to/cosmic_sorted.txt.gz
+     --plugin PON_P2,file=path/to/cosmic_sorted.txt.gz
    
-   If you use this data, please cite the following publication
-   Niroula, A., Vihinen, M. Harmful somatic amino acid substitutions affect key pathways in cancers.
-   BMC Med Genomics 8, 53 (2015). https://doi.org/10.1186/s12920-015-0125-x
+ If you use this data, please cite the following publication
+ Niroula, A., Vihinen, M. Harmful somatic amino acid substitutions affect key pathways in cancers.
+ BMC Med Genomics 8, 53 (2015). https://doi.org/10.1186/s12920-015-0125-x
  
 
 =cut

--- a/ProteinSeqs.pm
+++ b/ProteinSeqs.pm
@@ -29,6 +29,7 @@ limitations under the License.
 
  mv ProteinSeqs.pm ~/.vep/Plugins
  ./vep -i variations.vcf --plugin ProteinSeqs,reference.fa,mutated.fa
+ ./vep -i variations.vcf --plugin ProteinSeqs,reference=reference.fa,mutated=mutated.fa
 
 =head1 DESCRIPTION
 
@@ -76,9 +77,18 @@ sub new {
     }
 
     # use some default file names if none are supplied
+    my $params = $self->params_to_hash();
+    my $ref_file;
+    my $mut_file;
 
-    my $ref_file = $self->params->[0] || 'reference.fa';
-    my $mut_file = $self->params->[1] || 'mutated.fa';
+    if (!%{$params}){
+      $ref_file = $self->params->[0] || 'reference.fa';
+      $mut_file = $self->params->[1] || 'mutated.fa';
+    } else {
+        $ref_file = $params->{reference} if (defined ($params->{reference}));
+        $mut_file = $params->{mutated} if (defined($params->{mutated}));
+    }
+
 
     open $self->{ref_file}, ">$ref_file" or die "Failed to open $ref_file";
     open $self->{mut_file}, ">$mut_file" or die "Failed to open $mut_file";

--- a/REVEL.pm
+++ b/REVEL.pm
@@ -97,10 +97,21 @@ sub new {
   $self->expand_left(0);
   $self->expand_right(0);
 
-  $self->get_user_params();
-
+  #$self->get_user_params();
+  my $params = $self->params_to_hash();
+  my @key_params;
+  my $file;
+  if (!%{$params}) {
+    @key_params = @{$self->params};
+    $file = $key_params[0];
+    $self->{no_match} = $key_params[1] if ( defined ($key_params[1] ) ); 
+  } else {
+    $file = $params->{file};
+    $self->{no_match} = $params->{no_match} if (defined ($params->{no_match}));
+  }
+  
  # get column count in REVEL file from header line
-  my $file = $self->params->[0];
+  
   $self->add_file($file);
   open HEAD, "tabix -fh $file 1:1-1 2>&1 | ";
   while(<HEAD>) {
@@ -128,10 +139,6 @@ sub new {
       die "ERROR: Assembly is " . $assembly .
           " but REVEL file does not contain " .
           $assembly_to_hdr{$assembly} . " in header.\n";
-  }
-
-  if(defined($self->params->[1])) {
-    $self->{no_match} = $self->params->[1];
   }
 
   return $self;

--- a/REVEL.pm
+++ b/REVEL.pm
@@ -28,8 +28,8 @@ limitations under the License.
 =head1 SYNOPSIS
 
  mv REVEL.pm ~/.vep/Plugins
- ./vep -i variations.vcf --assembly GRCh37 --plugin REVEL,/path/to/revel/data.tsv.gz
- ./vep -i variations.vcf --assembly GRCh38 --plugin REVEL,/path/to/revel/data.tsv.gz
+ ./vep -i variations.vcf --assembly GRCh37 --plugin REVEL,file=/path/to/revel/data.tsv.gz
+ ./vep -i variations.vcf --assembly GRCh38 --plugin REVEL,file=/path/to/revel/data.tsv.gz
 
 =head1 DESCRIPTION
 

--- a/REVEL.pm
+++ b/REVEL.pm
@@ -66,7 +66,7 @@ limitations under the License.
  tabix -f -s 1 -b 3 -e 3 new_tabbed_revel_grch38.tsv.gz
 
  The plugin can then be run as default:
- ./vep -i variations.vcf --assembly GRCh38 --plugin REVEL,/path/to/revel/data.tsv.gz
+ ./vep -i variations.vcf --assembly GRCh38 --plugin REVEL,file=/path/to/revel/data.tsv.gz
 
  or with the option to not match by transcript id:
  ./vep -i variations.vcf --assembly GRCh38 --plugin REVEL,file=/path/to/revel/data.tsv.gz,no_match=1

--- a/REVEL.pm
+++ b/REVEL.pm
@@ -69,7 +69,6 @@ limitations under the License.
  ./vep -i variations.vcf --assembly GRCh38 --plugin REVEL,/path/to/revel/data.tsv.gz
 
  or with the option to not match by transcript id:
- ./vep -i variations.vcf --assembly GRCh38 --plugin REVEL,/path/to/revel/data.tsv.gz,1
  ./vep -i variations.vcf --assembly GRCh38 --plugin REVEL,file=/path/to/revel/data.tsv.gz,no_match=1
 
  Requirements:
@@ -97,6 +96,7 @@ sub new {
 
   $self->expand_left(0);
   $self->expand_right(0);
+  $self->get_user_params();
 
   #$self->get_user_params();
   my $params = $self->params_to_hash();

--- a/REVEL.pm
+++ b/REVEL.pm
@@ -70,6 +70,7 @@ limitations under the License.
 
  or with the option to not match by transcript id:
  ./vep -i variations.vcf --assembly GRCh38 --plugin REVEL,/path/to/revel/data.tsv.gz,1
+ ./vep -i variations.vcf --assembly GRCh38 --plugin REVEL,file=/path/to/revel/data.tsv.gz,no_match=1
 
  Requirements:
   The tabix utility must be installed in your path to use this plugin.
@@ -102,16 +103,15 @@ sub new {
   my @key_params;
   my $file;
   if (!%{$params}) {
-    @key_params = @{$self->params};
-    $file = $key_params[0];
-    $self->{no_match} = $key_params[1] if ( defined ($key_params[1] ) ); 
+    $file = $self->params->[0];
+    $self->{no_match} = $self->params->[1] if ( defined ($self->params->[1] ) ); 
   } else {
     $file = $params->{file};
     $self->{no_match} = $params->{no_match} if (defined ($params->{no_match}));
   }
   
  # get column count in REVEL file from header line
-  
+
   $self->add_file($file);
   open HEAD, "tabix -fh $file 1:1-1 2>&1 | ";
   while(<HEAD>) {


### PR DESCRIPTION
[ENSVAR-5551](https://www.ebi.ac.uk/panda/jira/browse/ENSVAR-5551)
We need to be able to call multiple options using option names like `file = ,option1= , option2=` while still maintaining legacy for  reproducibility. 
This PR adds this feature. 
**Test can be done using all plugins affected.** 
_For example using REVEL and assembly GRCh37_
`--plugin REVEL,file=PATH_to_REVEL_file,no_match=1`
Test to check for old legacy 
`--plugin REVEL,PATH_to_REVEL_file,1`