### PR TITLE
Add non-commercial clause in CADD plugin

### DIFF
--- a/CADD.pm
+++ b/CADD.pm
@@ -70,21 +70,23 @@ my %SV_TERMS = (
 my %INCLUDE_COLUMNS = (
     "PHRED" => {
       "name" => "CADD_PHRED",
-      "description" => 'PHRED-like scaled CADD score'
+      "description" => 'PHRED-like scaled CADD score.'
     },
     "RawScore" => {
       "name" => "CADD_RAW",
-      "description" => 'Raw CADD score'
+      "description" => 'Raw CADD score.'
     },
     "CADD-SV_PHRED-score" => {
       "name" => "CADD_PHRED",
-      "description" => 'PHRED-like scaled CADD score'
+      "description" => 'PHRED-like scaled CADD score.'
     },
     "CADD-SV_Raw-score" => {
       "name" => "CADD_RAW",
-      "description" => 'Raw CADD score'
+      "description" => 'Raw CADD score.'
     }
 );
+
+my $NON_COMMERCIAL_USE_CLAUSE = "CADD is only available here for non-commercial use. See CADD website for more information.";
 
   my $ALT_NUM = 0;
 
@@ -147,7 +149,7 @@ sub new {
     for (split /\t/, $self->{$file}){
       next unless (exists($INCLUDE_COLUMNS{$_}));
       $file_check = 1;
-      $self->{header}{$INCLUDE_COLUMNS{$_}{"name"}} = $INCLUDE_COLUMNS{$_}{"description"};
+      $self->{header}{$INCLUDE_COLUMNS{$_}{"name"}} = $INCLUDE_COLUMNS{$_}{"description"} . " " . $NON_COMMERCIAL_USE_CLAUSE;
     }
 
     die "\nERROR: $file does not have a known column to be included" unless $file_check;

--- a/plugin_config.txt
+++ b/plugin_config.txt
@@ -1704,7 +1704,7 @@ my $VEP_PLUGIN_CONFIG = {
       "label" => "IntAct",
       "available" => 0,
       "enabled" => 0,
-      "section" => "Functional effect",
+      "section" => "Protein annotation",
       "helptip" => "IntAct provides molecular interaction data for variants as reported by IntAct database",
       "plugin_url" => "https://raw.githubusercontent.com/Ensembl/VEP_plugins/release/110/IntAct.pm",
       "requires_data" => 1,
@@ -1736,24 +1736,6 @@ my $VEP_PLUGIN_CONFIG = {
           ],
         },
       ]
-    },
-
-    # MaveDB
-    {
-      "key" => "MaveDB",
-      "label" => "MaveDB",
-      "available" => 0,
-      "enabled" => 0,
-      "section" => "Functional effect",
-      "helptip" => "MaveDB holds experimentally determined measures of variant effect",
-      "plugin_url" => "https://raw.githubusercontent.com/Ensembl/VEP_plugins/release/110/MaveDB.pm",
-      "requires_data" => 1,
-      "params"  => [
-        "#file=/path/to/MaveDB_variants.tsv.gz"
-      ],
-      "species" => [
-        "homo_sapiens"
-      ],
     },
 
     # mutfunc

--- a/plugin_config.txt
+++ b/plugin_config.txt
@@ -705,7 +705,7 @@ my $VEP_PLUGIN_CONFIG = {
       "available" => 0,
       "enabled" => 0,
       "section" => "Pathogenicity predictions",
-      "helptip" => "Combined Annotation Dependent Depletion (CADD) is a tool for scoring the deleteriousness of single nucleotide variants and insertion/deletion variants in the human genome. CADD integrates multiple annotations into one metric by contrasting variants that survived natural selection with simulated mutations.",
+      "helptip" => "Combined Annotation Dependent Depletion (CADD) is a tool for scoring the deleteriousness of single nucleotide variants and insertion/deletion variants in the human genome. CADD integrates multiple annotations into one metric by contrasting variants that survived natural selection with simulated mutations. CADD is only available here for non-commercial use. See CADD website for more information.",
       "plugin_url" => "https://raw.githubusercontent.com/Ensembl/VEP_plugins/release/110/CADD.pm",
       "requires_data" => 1,
       "species" => [
@@ -1704,7 +1704,7 @@ my $VEP_PLUGIN_CONFIG = {
       "label" => "IntAct",
       "available" => 0,
       "enabled" => 0,
-      "section" => "Protein annotation",
+      "section" => "Functional effect",
       "helptip" => "IntAct provides molecular interaction data for variants as reported by IntAct database",
       "plugin_url" => "https://raw.githubusercontent.com/Ensembl/VEP_plugins/release/110/IntAct.pm",
       "requires_data" => 1,
@@ -1736,6 +1736,24 @@ my $VEP_PLUGIN_CONFIG = {
           ],
         },
       ]
+    },
+
+    # MaveDB
+    {
+      "key" => "MaveDB",
+      "label" => "MaveDB",
+      "available" => 0,
+      "enabled" => 0,
+      "section" => "Functional effect",
+      "helptip" => "MaveDB holds experimentally determined measures of variant effect",
+      "plugin_url" => "https://raw.githubusercontent.com/Ensembl/VEP_plugins/release/110/MaveDB.pm",
+      "requires_data" => 1,
+      "params"  => [
+        "#file=/path/to/MaveDB_variants.tsv.gz"
+      ],
+      "species" => [
+        "homo_sapiens"
+      ],
     },
 
     # mutfunc


### PR DESCRIPTION
Added non-commercial clause in CADD.
- in the hover over text in web VEP input form
- in hover over text in web VEP ouput
- in the CLI VEP header text

sandbox test url - 
http://wp-np2-11.ebi.ac.uk:7070/Homo_sapiens/Tools/VEP/Results?tl=s3J5sj9oRvhlosWw-158
