### PR TITLE
Update G2P gnomaAD

### DIFF
--- a/G2P.pm
+++ b/G2P.pm
@@ -138,7 +138,9 @@ my %DEFAULTS = (
   af_monoallelic => 0.0001,
   af_biallelic => 0.005, 
 
-  af_keys => [qw(AA AFR AMR EA EAS EUR SAS gnomAD gnomAD_AFR gnomAD_AMR gnomAD_ASJ gnomAD_EAS gnomAD_FIN gnomAD_NFE gnomAD_OTH gnomAD_SAS)],
+  af_keys => [qw(AA AFR AMR EA EAS EUR SAS gnomAD gnomAD_AFR gnomAD_AMR gnomAD_ASJ gnomAD_EAS gnomAD_FIN gnomAD_NFE gnomAD_OTH gnomAD_SAS
+                 gnomADg gnomADg_AFR gnomADg_AMR gnomADg_ASJ gnomADg_EAS gnomADg_FIN gnomADg_NFE gnomADg_OTH gnomADg_SAS
+                 gnomADe gnomADe_AFR gnomADe_AMR gnomADe_ASJ gnomADe_EAS gnomADe_FIN gnomADe_NFE gnomADe_OTH gnomADe_SAS)],
 
   af_from_vcf_keys => [qw(uk10k topmed gnomADe gnomADe_r2.1.1 gnomADg gnomADg_v3.1.2)],
 


### PR DESCRIPTION
The G2P report is missing a few values because of the population's names in `af_keys`.
VEP cache includes gnomADe and gnomADg so we need to include that in G2P.

Test with the following variants:
```
#CHROM  POS     ID      REF     ALT     QUAL    FILTER  INFO    FORMAT  P1      P2      P3
1       92266456        rs1397019423    T       A       .       .       .       GT      1/1     ./.     ./.
1       92266710        rs759042428     A       G       .       .       .       GT      0/1     ./.     ./.
```

This PR replaces https://github.com/Ensembl/VEP_plugins/pull/609