### PR TITLE
Intact - support new data format 

### DIFF
--- a/IntAct.pm
+++ b/IntAct.pm
@@ -370,11 +370,9 @@ sub run {
   my $vf = $tva->variation_feature;
   my $tv = $tva->transcript_variation;
 
-  # get reference codon and HGVSp  
-  my $ref_codon = $tv->get_reference_TranscriptVariationAllele->codon if $tv;
+  # get HGVSp for the variant in question through variation API  
   my $hgvs = $tva->hgvs_protein;
-
-  return {} unless ($ref_codon and $hgvs);
+  return {} unless $hgvs;
 
   my @data =  @{$self->get_data($vf->{chr}, $vf->{start} - 2, $vf->{end})};
   
@@ -382,8 +380,8 @@ sub run {
     my ($id_ref, $id_des) = split /:/, $_->{id};
     my (undef, $hgvs_des) = split /:/, $hgvs;
     
-    # match variation
-    next unless ($id_des eq $hgvs_des and $_->{ref} eq $ref_codon);
+    # match HGVSp description to make sure we get the correct variant from data file
+    next unless $id_des eq $hgvs_des;
 
     # get matched lines from IntAct data file on the hgvs like description 
     my $intact_matches = $self->_match_id($id_ref, $id_des);

--- a/IntAct.pm
+++ b/IntAct.pm
@@ -122,7 +122,8 @@ my $taxonomy_lookup = {
   "rattus_norvegicus" => 10116,
   "gallus_gallus_gca000002315v5" => 9031,
   "saccharomyces_cerevisiae" => 559292,
-  "arabidopsis_thaliana" => 3702
+  "arabidopsis_thaliana" => 3702,
+  "drosophila_melanogaster" => 7227
 };
 
 sub new {

--- a/IntAct.pm
+++ b/IntAct.pm
@@ -47,7 +47,7 @@ limitations under the License.
  do this by following commands -
 
   a) filter, sort and then zip
-  grep -v -e '^$' -e '^[#\-]' mutation_gc_map.txt | sed '1s/.*/#&/' | sort -k1,1 -k2,2n -k3,3n | bgzip > mutation_gc_map.txt.gz
+  grep -v -e '^$' -e '^[#\-]' mutation_gc_map.txt | sed '1s/.*/#&/' | awk -F "\t" 'BEGIN { OFS="\t"} {if ($2 > $3) {a=$2; $2=$3; $3=a}; print $0 }' | sort -k1,1 -k2,2n -k3,3n | bgzip > mutation_gc_map.txt.gz
   
   b) create tabix indexed file -
   tabix -s 1 -b 2 -e 3 -f mutation_gc_map.txt.gz

--- a/IntAct.pm
+++ b/IntAct.pm
@@ -117,8 +117,8 @@ my $valid_fields = {
 
 # taxomy id for supported species
 my $taxonomy_lookup = {
-	"homo_sapiens" => 9606,
-	"mus_musculus" => 10090,
+  "homo_sapiens" => 9606,
+  "mus_musculus" => 10090,
   "rattus_norvegicus" => 10116,
   "gallus_gallus_gca000002315v5" => 9031,
   "saccharomyces_cerevisiae" => 559292,

--- a/plugin_config.txt
+++ b/plugin_config.txt
@@ -1760,8 +1760,13 @@ my $VEP_PLUGIN_CONFIG = {
         "@*"
       ],
       "species" => [
-	"homo_sapiens",
-	"mus_musculus"
+	      "homo_sapiens",
+	      "mus_musculus",
+        "rattus_norvegicus",
+        "gallus_gallus_gca000002315v5",
+        "saccharomyces_cerevisiae",
+        "arabidopsis_thaliana",
+        "drosophila_melanogaster"
       ],
       "form" => [
         {

--- a/plugin_config.txt
+++ b/plugin_config.txt
@@ -1760,8 +1760,8 @@ my $VEP_PLUGIN_CONFIG = {
         "@*"
       ],
       "species" => [
-	      "homo_sapiens",
-	      "mus_musculus",
+        "homo_sapiens",
+        "mus_musculus",
         "rattus_norvegicus",
         "gallus_gallus_gca000002315v5",
         "saccharomyces_cerevisiae",


### PR DESCRIPTION
We are intending to update IntAct plugin data to the latest published one -
[ENSVAR-5859](https://www.ebi.ac.uk/panda/jira/browse/ENSVAR-5859)

Please also check - https://github.com/Ensembl/ensembl-rest_private/pull/135

- The new data file have change in how they represent allele in the `mutation_gc_map.txt` file - before, it was ref codon (e.g. - ATC) and now it is aa change (e.g. - G>S). Updated code to support that.
- Added new supported species - drosophila melanogaster
- Added all supported species to web/REST VEP too.

### Test

test_data - 
```
drosophila
3L	16039727	.	C	T

mouse 
2	127970880	.	A	G	.	.	.
4	43553083	.	C	G	.	.	.
```

command - 
```
vep --force_overwrite --plugin IntAct,mapping_file=data_0206/mutation_gc_map.txt.gz,mutation_file=data_0206/mutations.tsv --tab --species mus_musculus --database --db_version 109 --i test_data
```

