### PR TITLE
Fix dbNSFP warning

### DIFF
--- a/dbNSFP.pm
+++ b/dbNSFP.pm
@@ -100,12 +100,12 @@ When running the plugin you must list at least one column to retrieve from the
 
 The plugin matches rows in the tabix-indexed dbNSFP file on:
 
- position
+ genomic position
  alt allele
  aaref - reference amino acid
  aaalt - alternative amino acid
 
-To match only on the first position and the alt allele use --pep_match=0
+To match only on the genomic position and the alt allele use pep_match=0
 
 --plugin dbNSFP,/path/to/dbNSFP.gz,pep_match=0,col1,col2
 
@@ -353,7 +353,7 @@ sub run {
     if ($self->{pep_match}) {
       $allele_string = join('/', $tmp_data->{aaref}, $tmp_data->{aaalt});
       $allele_string =~ s/X/*/g;
-      next if ($tva->pep_allele_string() ne $allele_string);
+      next if (!$tva->pep_allele_string() || $tva->pep_allele_string() ne $allele_string);
     }
 
     # make a clean copy as we're going to edit it


### PR DESCRIPTION
Plugin throws warning:
`Use of uninitialized value in string ne at VEP_plugins/dbNSFP.pm line 356, <$__ANONIO__> line 1.`


**Input**
`3       12046077        12046077        C/A     +`

**Command**
--plugin dbNSFP,'consequence=ALL',dbNSFP4.3a_grch37.gz,LINSIGHT,LINSIGHT_rankscore,gnomAD_genomes_AF