### PR TITLE
Avoid smartmatch operator

### DIFF
--- a/EVE.pm
+++ b/EVE.pm
@@ -110,10 +110,10 @@ sub new {
   my @valid_class_numbers = (10, 20, 25, 30, 40, 50, 60, 70, 75, 80, 90);
 
   if (defined($param_hash->{class_number})) {
-
-    die "\nERROR: This class_number: '$param_hash->{class_number}' does not exists.\nTry any of this numbers: " . join(', ', @valid_class_numbers)
-    unless ($param_hash->{class_number} ~~ @valid_class_numbers);
-    $self->{class_number} = $param_hash->{class_number};
+    my $class_number = $param_hash->{class_number});
+    die "\nERROR: This class_number: '$class_number' does not exists.\nTry any of this numbers: " . join(', ', @valid_class_numbers)
+      unless grep(/^$class_number$/, @valid_class_numbers);
+    $self->{class_number} = $class_number;
   } else {
     $self->{class_number} = 75;
   }

--- a/EVE.pm
+++ b/EVE.pm
@@ -110,8 +110,8 @@ sub new {
   my @valid_class_numbers = (10, 20, 25, 30, 40, 50, 60, 70, 75, 80, 90);
 
   if (defined($param_hash->{class_number})) {
-    my $class_number = $param_hash->{class_number});
-    die "\nERROR: This class_number: '$class_number' does not exists.\nTry any of this numbers: " . join(', ', @valid_class_numbers)
+    my $class_number = $param_hash->{class_number};
+    die "\nERROR: This class_number: '$class_number' does not exists.\nTry any of these numbers: " . join(', ', @valid_class_numbers)
       unless grep(/^$class_number$/, @valid_class_numbers);
     $self->{class_number} = $class_number;
   } else {

--- a/MaveDB.pm
+++ b/MaveDB.pm
@@ -117,7 +117,11 @@ sub _parse_colnames {
     $self->{cols} = \@cols;
 
     # Check validity of all columns
-    my @invalid_cols = grep { !($_ ~~ $self->{colnames}) } @cols;
+    my @invalid_cols;
+    for my $col (@{ $self->{cols} }) {
+      push(@invalid_cols, $col) unless grep(/^$col$/, @{ $self->{colnames} });
+    }
+
     die "\n  ERROR: The following columns were not found in file header: ",
       join(", ", @invalid_cols), "\n" if @invalid_cols;
   }

--- a/PON_P2.pm
+++ b/PON_P2.pm
@@ -101,7 +101,7 @@ sub new {
   if(!$from_file) {
     die 'ERROR: Path to python script not specified! Specify path to python script e.g. --plugin PON_P2,/path/to/python/client/for/ponp2.py,[hg37/hg38]\n' unless defined($pyscript);
     die 'ERROR: Reference genome not specified! Specify the reference genome after the path to python file e.g. --plugin PON_P2,/path/to/python/client/for/ponp2.py,[hg37/hg38]\n' unless defined($hg);
-    die "ERROR: Wrong reference genome specified! It should be either 'hg37' or 'hg38'\n" unless ($hg ~~ ["hg37","hg38"]);
+    die "ERROR: Wrong reference genome specified! It should be either 'hg37' or 'hg38'\n" unless grep(/^hg3[78]$/, $hg);
     die 'ERROR: Incorrect path to ponp2.py\n' unless -e $pyscript;
   }
 

--- a/TranscriptAnnotator.pm
+++ b/TranscriptAnnotator.pm
@@ -130,11 +130,11 @@ sub _get_selected_cols {
   if ( $param_hash->{cols} ) {
     # Check if user-selected columns are valid
     my @invalid_cols;
-    for ( split /:/, $param_hash->{cols} ) {
-      if ($_ ~~ @colnames) {
-        push @cols, $_;
+    for my $col ( split /:/, $param_hash->{cols} ) {
+      if (grep /^$col$/, @colnames) {
+        push @cols, $col;
       } else {
-        push @invalid_cols, $_;
+        push @invalid_cols, $col;
       }
     }
 


### PR DESCRIPTION
Replace smartmatch operator with equivalent functionality.

Smartmatch is an experimental feature that throws warnings in newer versions of Perl.