### PR TITLE
Update SpliceAI plugin to be human-only

### DIFF
--- a/plugin_config.txt
+++ b/plugin_config.txt
@@ -1179,6 +1179,9 @@ my $VEP_PLUGIN_CONFIG = {
       "enabled" => 0,
       "section" => "Splicing predictions",
       "plugin_url" => "https://raw.githubusercontent.com/Ensembl/VEP_plugins/release/111/SpliceAI.pm",
+      "species" => [
+        "homo_sapiens"
+      ],
       "form" => [
         {
           "name" => "file_type",


### PR DESCRIPTION
Currently, web VEP is hard-coded to consider all `Splicing predictions` as human-only (fixed in https://github.com/Ensembl/public-plugins/pull/716). This PR changes SpliceAI options to only appear for human in web VEP.

Test in [my sandbox](https://www.ensembl.org/Multi/Tools/VEP?db=core): SpliceAI options should only be available when human is selected.