### PR TITLE
Fix read-only warning when creating GO data

### DIFF
--- a/GO.pm
+++ b/GO.pm
@@ -324,7 +324,7 @@ sub _write_GO_terms_to_file {
   my $transcript_info;
   my $previous_transcript = "";
   while(my $row = $sth->fetchrow_arrayref()) {
-    my ($transcript_id, $go_term, $description) = splice(@$row, -3);
+    my ($transcript_id, $go_term, $description) = @$row[-3..-1];
 
     if ($transcript_id ne $previous_transcript) {
       # If not the same transcript, write previous transcript info to file

--- a/GO.pm
+++ b/GO.pm
@@ -323,8 +323,9 @@ sub _write_GO_terms_to_file {
   # when there is a new transcript, write $transcript_info to file and repeat
   my $transcript_info;
   my $previous_transcript = "";
-  while(my $row = $sth->fetchrow_arrayref()) {
-    my ($transcript_id, $go_term, $description) = @$row[-3..-1];
+  while(my $line = $sth->fetchrow_arrayref()) {
+    my $row = [ @$line ];
+    my ($transcript_id, $go_term, $description) = splice(@$row, -3);
 
     if ($transcript_id ne $previous_transcript) {
       # If not the same transcript, write previous transcript info to file


### PR DESCRIPTION
Fixes #622

May be related with Perl version used. Perl 5.34 returns the following warning: `WARNING: Failed to instantiate plugin GO: Modification of a read-only value attempted at /home/meryem/.vep/Plugins/GO.pm line 327`.

To avoid this issue, simply get a slice of `@$row` instead of using `splice()` that tries to modify the original array.

# Test

Try to create GO plugin data with: `./vep --id rs699 --database --plugin GO`