### PR TITLE
MaveDB: return data for regulatory regions

### DIFF
--- a/MaveDB.pm
+++ b/MaveDB.pm
@@ -247,7 +247,8 @@ sub run {
   # Get allele
   my $allele = $tva->base_variation_feature->alt_alleles;
 
-  my @data = @{$self->get_data($vf->{chr}, $vf->{start} - 2, $vf->{end})};
+  # Increment 1 to account for insertions
+  my @data = @{$self->get_data($vf->{chr}, $vf->{start} - 2, $vf->{end} + 1)};
 
   my $all_results = {};
   foreach (@data) {

--- a/MaveDB.pm
+++ b/MaveDB.pm
@@ -267,7 +267,7 @@ sub run {
     # Check if transcripts match
     if ($self->{transcript_match}) {
       my $transcript = $_->{result}->{MaveDB_refseq};
-      next unless $self->_transcripts_match($tva, $transcript);
+      next unless $transcript eq '' or $self->_transcripts_match($tva, $transcript);
     }
 
     my $matches = get_matched_variant_alleles(

--- a/MaveDB.pm
+++ b/MaveDB.pm
@@ -204,7 +204,7 @@ sub _transcripts_match {
 
   # Get transcript ID for Ensembl and RefSeq
   my $tr = $tva->transcript;
-  my @refseq = split(/,/, $tr->{_refseq}) unless $tr->{_refseq} eq '-';
+  my @refseq = split(/,/, $tr->{_refseq}) if defined $tr->{_refseq} and $tr->{_refseq} ne '-';
   my @tr_id  = ( $tr->{stable_id}, @refseq );
 
   return grep { $transcript eq $_ =~ s/\.[0-9]+//gr } @tr_id;


### PR DESCRIPTION
[ENSVAR-5960](https://www.ebi.ac.uk/panda/jira/browse/ENSVAR-5960): Ensure MaveDB VEP plugin works with regulatory data

### Changelog

This PR:
- skips the transcript matching if the MaveDB plugin data has no associated transcript (example: variants in regulatory regions, such as `NC_000023.11:g.139530529T>G`)
- increment 1 to end position to enable searching for insertions (such as `NC_000001.11:g.226361437_226361438insCGG`)

### Testing

Please use the location of the MaveDB plugin data mentioned in the JIRA ticket, updated based on https://github.com/Ensembl/ensembl-variation/pull/1035 (110 data won't work for this variant).

#### Example variants (all must return MaveDB scores)
```
NC_000023.11:g.139530529T>G
NC_000001.11:g.226361445_226361446delinsG
NC_000001.11:g.226361437_226361438insCGG
NC_000001.11:g.226361517_226361520del
NC_000001.11:g.226362048del
```

#### Example command
```bash
perl vep --database --i sample.txt --plugin MaveDB,file=MaveDB_variants.tsv.gz
```