### PR TITLE
RiboseqORFs plugin

### DIFF
--- a/RiboseqORFs.pm
+++ b/RiboseqORFs.pm
@@ -1,0 +1,214 @@
+=head1 LICENSE
+
+Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
+Copyright [2016-2023] EMBL-European Bioinformatics Institute
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=head1 CONTACT
+
+ Ensembl <http://www.ensembl.org/info/about/contact/index.html>
+
+=cut
+
+=head1 NAME
+
+ RiboseqORFs
+
+=head1 SYNOPSIS
+
+ ./vep -i variations.vcf --plugin RiboseqORFs,file=/path/to/Ribo-seq_ORFs.bed.gz
+
+=head1 DESCRIPTION
+
+ This is a VEP plugin that uses a standardized catalog of human Ribo-seq ORFs to
+ re-calculate consequences for variants located in these translated regions.
+
+ This plugin reports new consequences based on the evidence from the Ribo-seq
+ ORF annotation and supporting publications. The human Ribo-seq ORF data can be
+ downloaded from: https://ftp.ebi.ac.uk/pub/databases/gencode/riboseq_orfs/data
+
+ After downloading the annotation, please bgzip and tabix it:
+   bgzip Ribo-seq_ORFs.bed
+   tabix Ribo-seq_ORFs.bed.gz
+
+ Please cite the publication for the Ribo-seq ORF annotation alongside the VEP
+ if you use this resource: https://doi.org/10.1038/s41587-022-01369-0
+
+ The tabix utility must be installed in your path to use this plugin.
+
+=cut
+
+package RiboseqORFs;
+
+use strict;
+use warnings;
+
+use Bio::EnsEMBL::Variation::Utils::BaseVepTabixPlugin;
+
+use base qw(Bio::EnsEMBL::Variation::Utils::BaseVepTabixPlugin);
+
+sub new {
+  my $class = shift;
+  my $self  = $class->SUPER::new(@_);
+
+  $self->expand_left(0);
+  $self->expand_right(0); 
+  $self->get_user_params();
+
+  # Add plugin data file
+  my $param_hash = $self->params_to_hash();
+  my $file = $param_hash->{file};
+  die "\n  ERROR: No file specified\nTry using 'file=path/to/Ribo-seq_ORFs.bed.gz'\n"
+     unless defined($file);
+  $self->add_file($file);
+
+  return $self;
+}
+
+sub feature_types {
+  return ['Transcript'];
+}
+
+sub get_header_info {
+  return {
+    RiboseqORFs_id           => 'Ribo-seq ORF identifier',
+    RiboseqORFs_consequences => 'Recalculated consequences based on Ribo-seq ORF evidence',
+    RiboseqORFs_impact       => 'Impact rating of the worst recalculated consequence',
+    RiboseqORFs_publications => 'Associated publications',
+  };
+}
+
+sub _transcripts_match {
+  my ($tva, $transcripts) = @_;
+
+  # Get transcript ID for Ensembl
+  my $tr = $tva->transcript->{stable_id};
+
+  my @all_trs = split(/,/, $transcripts);
+  return grep { $tr eq $_ } @all_trs;
+}
+
+sub _recreate_transcriptVariation_with_ORF {
+  my $tva = shift;
+  my $orf = shift;
+
+  my $vf = $tva->variation_feature;  
+  my $tr = $tva->transcript;
+  my $strand = $_->{strand} eq '+' ? 1 : -1;
+
+  # Create one exon for each ORF block
+  my $exons;
+  my @block_start = split(',', $orf->{chromStarts});
+  my @block_size  = split(',', $orf->{blockSize});
+
+  for my $k ( 0 .. $orf->{blockCount} - 1 ) {
+    my $exon_start = $orf->{chromStart} + $block_start[$k];
+    my $exon_end   = $exon_start + $block_size[$k];
+    push @$exons, Bio::EnsEMBL::Exon->new(
+                    -SLICE     => $tr->slice,
+                    -START     => $exon_start + 1,
+                    -END       => $exon_end,
+                    -STRAND    => $strand,
+                    -PHASE     => 0,
+                    -END_PHASE => 0,
+                  );
+  }
+  $exons = [ reverse @$exons ] if $strand == -1;
+
+  # Create new transcript with previous exons
+  my $new_tr = Bio::EnsEMBL::Transcript->new(
+    -BIOTYPE => 'protein_coding',
+    -START   => $orf->{chromStart},
+    -END     => $orf->{chromEnd},
+    -STRAND  => $strand,
+    -EXONS   => $exons,
+  );
+
+  # Create respective translation
+  $new_tr->translation(Bio::EnsEMBL::Translation->new(
+    -START_EXON => $exons->[0],
+    -END_EXON   => $exons->[-1],
+    -SEQ_START  => 1,
+    -SEQ_END    => length($new_tr->spliced_seq),
+  ));
+
+  # Check if translation matches the one from annotation
+  my $seq_pred  = $new_tr->translation->seq;
+  my $seq_annot = $orf->{sequence};
+  my $var       = $tva->variation_feature->name;
+  die "Unexpected translation sequence for ${var}:\n" .
+      "  - Predicted: ${seq_pred}\n" .
+      "  - Annotated: ${seq_annot}\n" if $seq_pred ne $seq_annot;
+
+  # Create TranscriptVariation object
+  my $tv = Bio::EnsEMBL::Variation::TranscriptVariation->new(
+    -transcript        => $new_tr,
+    -variation_feature => $vf,
+  );
+  return $tv;
+}
+
+sub run {
+  my ($self, $tva) = @_;
+  my $vf   = $tva->variation_feature;
+  my @data = @{$self->get_data($vf->{chr}, $vf->{start}, $vf->{end})};
+  
+  for (@data) {
+    next unless _transcripts_match($tva, $_->{'all_transcript_ids'});
+
+    my $tv_orf       = _recreate_transcriptVariation_with_ORF($tva, $_);
+    my $consequences = $tv_orf->consequence_type;
+    my $impact       = $tv_orf->most_severe_OverlapConsequence->impact;
+    my $publications = [ split(",", $_->{ref_studies}) ];
+
+    my $res = {
+      RiboseqORFs_id           => $_->{name},
+      RiboseqORFs_consequences => $consequences,
+      RiboseqORFs_impact       => $impact,
+      RiboseqORFs_publications => $publications,
+    };
+
+    # Group results for JSON and REST
+    if ($self->{config}->{output_format} eq 'json' || $self->{config}->{rest}) {
+      $res = { "RiboseqORFs" => $res };
+    }
+    return $res;
+  }
+  return {};
+}
+
+sub parse_data {
+  my ($self, $line) = @_;
+
+  my %output_hash;
+  my @header = qw{
+    chrom chromStart chromEnd name score strand thickStart thickEnd reserved
+    blockCount blockSize chromStarts name2 cdsStartStat cdsEndStat exonFrames
+    type geneName geneName2 geneType transcript_biotype sequence
+    all_transcript_ids all_gene_ids replicated ref_studies
+  };
+  @output_hash{ @header } = split /\t/, $line;
+  return \%output_hash;
+}
+
+
+sub get_start {
+  return $_[1]->{start};
+}
+
+sub get_end {
+  return $_[1]->{end};
+}
+
+1;

--- a/RiboseqORFs.pm
+++ b/RiboseqORFs.pm
@@ -77,7 +77,7 @@ sub new {
 }
 
 sub feature_types {
-  return ['Transcript'];
+  return [ 'Feature', 'Intergenic' ];
 }
 
 sub get_header_info {

--- a/plugin_config.txt
+++ b/plugin_config.txt
@@ -1747,6 +1747,16 @@ my $VEP_PLUGIN_CONFIG = {
       "plugin_url" => "https://raw.githubusercontent.com/Ensembl/VEP_plugins/release/111/TranscriptAnnotator.pm"
     },
 
+    # RiboseqORFs
+    {
+      "key" => "RiboseqORFs",
+      "label" => "RiboseqORFs",
+      "available" => 0,
+      "enabled" => 0,
+      "section" => "Transcript annotation",
+      "plugin_url" => "https://raw.githubusercontent.com/Ensembl/VEP_plugins/release/111/RiboseqORFs.pm"
+    },
+
     ## PROTEIN DATA
     ###############
 


### PR DESCRIPTION
ENSVAR-5966: Re-calculate consequences of a variant/transcript pair based on ORF annotation from Havana.

## Logic

The ORF data includes compatible transcripts with each ORF. If the current Ensembl transcript ID is not in the list, we skip it.

To get the consequences, we simply need to use the existing **VariationFeature** object and create a mock **Transcript** based on ORF features, where each **ORF block** is considered as an **exon**. We join both features in a new **TranscriptVariationAllele** object.

From this object, we calculate the variation consequences as usual in VEP. This will append the following data:
- `RiboseqORFs_consequences`: Recalculated consequences based on Ribo-seq ORF evidence
- `RiboseqORFs_id`: Ribo-seq ORF identifier
- `RiboseqORFs_impact`: Impact rating of the worst recalculated consequence
- `RiboseqORFs_publications`

**UPDATE 4681764** now also appending the following data:
- `RiboseqORFs_cDNA_position`
- `RiboseqORFs_CDS_position`
- `RiboseqORFs_protein_position `
- `RiboseqORFs_amino_acids`
- `RiboseqORFs_codons`

## Questions

- Should we change directly the value of IMPACT and CONSEQUENCE or add new plugin-specific columns with such data? Users may want to compare to see if there is any difference (there are cases where having an ORF makes no difference to the observed consequences).
- What is the need for phase/end_phase in exons?
- What is the category of the plugin? Transcript annotation?

## Testing

Run the plugin with input such as:
```
1  826872  rs1267085174  T  C
1  21002740  COSV51683564  C  N
1  21002752  COSV99943953  G  N
1  21002755  rs762454293  T  C,G
1  41142995  COSV58239640  G  N
1  41142996  rs1419160985  A  G
1  41144094  rs1483694223  GG  G
1  54053777  rs553713664  C  A,G
1  54053955  rs1463406779  G  T
1  54054111  rs1557683911  G  C
1  54054116  rs890941017  A  G
1  230710048  rs699  A  G
4  20727340  rs1302041407  GAAG  G
4  20727342  rs1358042038  AGAAGGGA  A
4  20727380  COSV99764287  A  N
4  20727386  rs772785267  C  G,T
4  20727408  rs1288221118  ATTTA  A
10  43644034  COSV100986477  C  N
10  43644040  rs897465984  A  C
10  43644065  rs1394289463  C  G,T
10  43644166  COSV100986481  C  N
14  23183069  rs1398838202  C  A
17  6651831  rs1032226647  C  A,G
17  35474880  rs139184648  G  A
19  4769263  rs759134393  G  A
19  4769247  rs1342088513  G  A
19  7918923  rs1019571642  T  G
19  7918918  rs1568287255  G  T
X  66598008  rs1339258298  C  T
X  66598105  rs1163061834  G  A
X  66598344  rs532138207  T  C
X  66599492  rs774714133  T  C
X  66599481  rs1035889065  G  C
X  66599480  COSV53631292  A  N
X  66599508  COSV99491151  C  N
X  66599505  rs142591870  G  A,C
```

Check if the re-calculated consequences make sense.

Also check if the output in JSON format looks good.