### PR TITLE
Add paralogue variants plugin

### DIFF
--- a/Paralogues.pm
+++ b/Paralogues.pm
@@ -92,6 +92,10 @@ limitations under the License.
                   `clnsig`: 'partial' (default), 'exact' or 'regex'
    clnsig_col   : Column name containing clinical significance in custom VCF
                   (required if using both `vcf` and `clnsig` arguments)
+   min_perc_cov : Minimum alignment percentage of the peptide associated with
+                  the input variant (default: 0)
+   min_perc_pos : Minimum percentage of positivity (similarity) between both
+                  homologues (default: 50)
    mode         : If 'remote', fetch paralogue annotation directly from Ensembl
                   API (default: off); paralogue variants can either be fetched
                   from a custom VCF using the argument `vcf` or Ensembl API
@@ -374,6 +378,8 @@ sub _get_paralogues {
       $para_cigar
     ) = split /\t/, $_;
     next unless $translation_id eq $protein_id;
+    next unless $perc_cov >= $self->{min_perc_cov};
+    next unless $perc_pos >= $self->{min_perc_pos};
 
     my $paralogue = $self->_get_transcript_from_translation(
       $para_id, $para_chr, $para_start, $para_end);
@@ -502,6 +508,10 @@ sub new {
 
   my $params = $self->params_to_hash();
   my $config = $self->{config};
+
+  # Thresholds for minimum percentage of homology similarity and coverage
+  $self->{min_perc_cov} = $params->{min_perc_cov} ? $params->{min_perc_cov} : 0;
+  $self->{min_perc_pos} = $params->{min_perc_pos} ? $params->{min_perc_pos} : 0;
 
   # Check for custom VCF
   my $vcf = $params->{vcf};

--- a/Paralogues.pm
+++ b/Paralogues.pm
@@ -47,6 +47,11 @@ limitations under the License.
  acids aligned between paralogue proteins. This is useful to predict
  pathogenicity of variants in paralogue positions.
 
+ This plugin fetches variants overlapping the genomic coordinates of the
+ paralogue's affected aminoacid from one of two sources:
+ - Custom VCF based on vcf parameter
+ - Ensembl API (if vcf parameter is not defined)
+
  This plugin automatically downloads paralogue annotation from Ensembl databases
  if not available in the current directory (by default). Use argument `dir` to
  change the directory of the paralogue annotation:

--- a/Paralogues.pm
+++ b/Paralogues.pm
@@ -91,7 +91,7 @@ limitations under the License.
    clnsig_match : Type of match when filtering variants based on argument
                   `clnsig`: 'partial' (default), 'exact' or 'regex'
    clnsig_col   : Column name containing clinical significance in custom VCF
-                  (required if using `vcf`)
+                  (required if using both `vcf` and `clnsig` arguments)
    mode         : If 'remote', fetch paralogue annotation directly from Ensembl
                   API (default: off); paralogue variants can either be fetched
                   from a custom VCF using the argument `vcf` or Ensembl API

--- a/Paralogues.pm
+++ b/Paralogues.pm
@@ -336,6 +336,9 @@ sub _get_paralogue_coords {
   my $translation_id    = $tva->transcript->translation->stable_id;
   my $translation_start = $tva->base_variation_feature_overlap->translation_start;
 
+  # avoid cases where $translation_start is located in stop codon
+  return unless $translation_start <= $tva->transcript->translation->length;
+
   # identify paralogue protein
   my @proteins = keys %{ $aln->{'_start_end_lists'} };
   my $paralogue;

--- a/Paralogues.pm
+++ b/Paralogues.pm
@@ -559,7 +559,7 @@ sub _get_valid_fields {
 
   die "ERROR: all fields given are invalid. Available fields are:\n" .
     join(", ", @$available)."\n" unless @valid;
-  warn "WARNING: the following fields are not valid and were ignored: ",
+  warn "Paralogues plugin: WARNING: the following fields are not valid and were ignored: ",
     join(", ", @invalid), "\n" if @invalid;
 
   return \@valid;

--- a/Paralogues.pm
+++ b/Paralogues.pm
@@ -68,7 +68,8 @@ limitations under the License.
  To avoid downloading any data locally, the plugin also has a remote mode. The
  remote mode also supports fetching variants from a custom VCF file:
    --plugin Paralogues,mode=remote
-   --plugin Paralogues,mode=remote,vcf=/path/to/file.vcf
+   --plugin Paralogues,mode=remote,vcf=/path/to/file.vcf.gz
+   --plugin Paralogues,mode=remote,vcf=/path/to/file.vcf.gz,cols=CLNSIG:CLNVI:GENEINFO
 
  The tabix utility must be installed in your path to read the paralogue
  annotation and the custom VCF file.

--- a/Paralogues.pm
+++ b/Paralogues.pm
@@ -43,8 +43,29 @@ limitations under the License.
 
 =head1 DESCRIPTION
 
- A VEP plugin that fetches variants from paralogue proteins.
- 
+ A VEP plugin that fetches variants overlapping the genomic coordinates of amino
+ acids aligned between paralogue proteins.
+
+ This plugin automatically downloads paralogue annotation from Ensembl databases
+ if not available in the current directory (by default). Use argument `dir` to
+ change the directory of the paralogue annotation:
+   --plugin Paralogues,dir=/path/to/dir
+
+ It is also possible to point to a custom tabix-indexed TSV file by using
+ argument `paralogues`:
+   --plugin Paralogues,paralogues=file.tsv.gz
+   --plugin Paralogues,dir=/path/to/dir,paralogues=paralogues_file.tsv.gz
+   --plugin Paralogues,paralogues=/path/to/dir/paralogues_file.tsv.gz
+
+ The overlapping variants can be fetched from Ensembl API (by default) or a
+ custom VCF file. To fetch variants from a VCF, use argument `vcf`:
+   --plugin Paralogues,vcf=/path/to/file.vcf
+
+ To avoid downloading data locally, the plugin also has a remote mode that
+ optionally supports a custom VCF file:
+   --plugin Paralogues,mode=remote
+   --plugin Paralogues,mode=remote,vcf=/path/to/file.vcf
+
  The tabix utility must be installed in your path to use this plugin.
 
 =cut

--- a/Paralogues.pm
+++ b/Paralogues.pm
@@ -88,12 +88,11 @@ use base qw(Bio::EnsEMBL::Variation::Utils::BaseVepTabixPlugin);
 sub _prepare_filename {
   my $self = shift;
   my $config = $self->{config};
-  my $reg    = $config->{reg};
 
   # Prepare file name based on species, database version and assembly
   my $pkg      = __PACKAGE__.'.pm';
   my $species  = $config->{species};
-  my $version  = $config->{db_version} || $reg->software_version;
+  my $version  = $config->{db_version} || 'Bio::ensembl::Registry'->software_version;
   my @name     = ($pkg, $species, $version);
 
   if( $species eq 'homo_sapiens' || $species eq 'human'){

--- a/Paralogues.pm
+++ b/Paralogues.pm
@@ -511,7 +511,7 @@ sub new {
 
   # Thresholds for minimum percentage of homology similarity and coverage
   $self->{min_perc_cov} = $params->{min_perc_cov} ? $params->{min_perc_cov} : 0;
-  $self->{min_perc_pos} = $params->{min_perc_pos} ? $params->{min_perc_pos} : 0;
+  $self->{min_perc_pos} = $params->{min_perc_pos} ? $params->{min_perc_pos} : 50;
 
   # Check for custom VCF
   my $vcf = $params->{vcf};
@@ -657,10 +657,12 @@ sub _summarise_vf {
 
 sub _is_clinically_significant {
   my ($self, $clnsig) = @_;
-  return 0 unless any { defined } @$clnsig;
 
+  # if no filter is set, avoid filtering
   my $filter = $self->{clnsig_term};
-  return 0 unless defined $filter;
+  return 1 unless defined $filter;
+
+  return 0 unless any { defined } @$clnsig;
 
   my $res;
   my $match = $self->{clnsig_match};

--- a/Paralogues.pm
+++ b/Paralogues.pm
@@ -44,7 +44,8 @@ limitations under the License.
 =head1 DESCRIPTION
 
  A VEP plugin that fetches variants overlapping the genomic coordinates of amino
- acids aligned between paralogue proteins.
+ acids aligned between paralogue proteins. This is useful to predict
+ pathogenicity of variants in paralogue positions.
 
  This plugin automatically downloads paralogue annotation from Ensembl databases
  if not available in the current directory (by default). Use argument `dir` to

--- a/Paralogues.pm
+++ b/Paralogues.pm
@@ -1,0 +1,252 @@
+=head1 LICENSE
+
+Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
+Copyright [2016-2023] EMBL-European Bioinformatics Institute
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=head1 CONTACT
+
+ Ensembl <http://www.ensembl.org/info/about/contact/index.html>
+
+=cut
+
+=head1 NAME
+
+ Paralogues
+
+=head1 SYNOPSIS
+
+ mv Paralogues.pm ~/.vep/Plugins
+
+ # Fetch Ensembl variants in paralogue proteins (requires database access) -- slowest mode
+ ./vep -i variations.vcf --database --plugin Paralogues
+
+ # Fetch variants from custom VCF file based on Ensembl paralogues (requires database access)
+ ./vep -i variations.vcf --database --plugin Paralogues,vcf=/path/to/file.vcf
+
+=head1 DESCRIPTION
+
+ A VEP plugin that fetches variants from paralogue proteins.
+ 
+ The tabix utility must be installed in your path to use this plugin.
+
+=cut
+
+package Paralogues;
+
+use strict;
+use warnings;
+
+use Bio::EnsEMBL::Utils::Sequence qw(reverse_comp);
+use Bio::EnsEMBL::Variation::Utils::Sequence qw(get_matched_variant_alleles);
+
+use Bio::EnsEMBL::Variation::Utils::BaseVepTabixPlugin;
+use base qw(Bio::EnsEMBL::Variation::Utils::BaseVepTabixPlugin);
+
+sub new {
+  my $class = shift;  
+  my $self = $class->SUPER::new(@_);
+
+  $self->expand_left(0);
+  $self->expand_right(0);
+  $self->get_user_params();
+
+  # Check files in arguments
+  my $params = $self->params_to_hash();
+  $self->add_file($params->{vcf}) if defined $params->{vcf};
+
+  return $self;
+}
+
+sub feature_types {
+  return ['Feature', 'Intergenic'];
+}
+
+sub get_header_info {
+  my $self = shift;
+
+  my $header = {
+    PARALOGUE_VARIANT_ID          => 'Paralogue variant identifier',
+    PARALOGUE_VARIANT_SEQNAME     => 'Paralogue variant sequence region name',
+    PARALOGUE_VARIANT_START       => 'Paralogue variant start',
+    PARALOGUE_VARIANT_ALLELES     => 'Paralogue variant alleles',
+  };
+
+  if ( @{$self->{_files}} ) {
+    $header->{'PARALOGUE_VARIANT_INFO_*'} = 'Paralogue variant fields based on VCF INFO field';
+  } else {
+    $header->{'PARALOGUE_VARIANT_STRAND'}      = 'Paralogue variant strand';
+    $header->{'PARALOGUE_VARIANT_END'}         = 'Paralogue variant end';
+    $header->{'PARALOGUE_VARIANT_CLNSIG'}      = 'Paralogue variant clinical significance';
+    $header->{'PARALOGUE_VARIANT_SOURCE'}      = 'Paralogue variant source';
+    $header->{'PARALOGUE_VARIANT_CONSEQUENCE'} = 'Paralogue variant consequence type(s)';
+  }
+  return $header;
+}
+
+sub _join_results {
+  my $self = shift;
+  my $all_results = shift;
+  my $res = shift;
+
+  if ($self->{config}->{output_format} eq 'json' || $self->{config}->{rest}) {
+    # Group results for JSON and REST
+    $all_results->{"Paralogues"} = [] unless defined $all_results->{"Paralogues"};
+    push(@{ $all_results->{"Paralogues"} }, $res);
+  } else {
+    # Create array of results per key
+    for (keys %$res) {
+      $all_results->{$_} = [] if !$all_results->{$_};
+      push(@{ $all_results->{$_} }, $res->{$_} || "NA");
+    }
+  }
+  return $all_results;
+}
+
+sub _summarise_vf {
+  my $vf = shift;
+  return {
+    PARALOGUE_VARIANT_ID          => $vf->name,
+    PARALOGUE_VARIANT_SEQNAME     => $vf->seq_region_name,
+    PARALOGUE_VARIANT_STRAND      => $vf->strand,
+    PARALOGUE_VARIANT_START       => $vf->seq_region_start,
+    PARALOGUE_VARIANT_END         => $vf->seq_region_end,
+    PARALOGUE_VARIANT_ALLELES     => $vf->allele_string,
+    PARALOGUE_VARIANT_CLNSIG      => join('/', @{$vf->get_all_clinical_significance_states}),
+    PARALOGUE_VARIANT_SOURCE      => $vf->source_name,
+    PARALOGUE_VARIANT_CONSEQUENCE => $vf->display_consequence,
+  };
+}
+
+sub run {
+  my ($self, $tva) = @_;
+
+  my $vf = $tva->variation_feature;
+
+  my $transcript = $tva->transcript;
+  my ($pep_coords) = $transcript->genomic2pep($vf->start, $vf->end, $transcript->strand);
+
+  # return empty hash if there is no match from genomic to peptide coordinates
+  return {} if ref $pep_coords eq 'Bio::EnsEMBL::Mapper::Gap';
+
+  my $species = $self->{config}->{species};
+  my $config  = $self->{config};
+  my $reg     = $config->{reg};
+
+  my $ta      = $reg->get_adaptor($species, 'core', 'translation');
+  my $sa      = $reg->get_adaptor($species, 'core', 'slice');
+  my $vfa     = $reg->get_adaptor($species, 'variation', 'variationfeature');
+
+  # reconnect to DB without species param
+  if ($config->{host}) {
+    $reg->load_registry_from_db(
+      -host       => $config->{host},
+      -user       => $config->{user},
+      -pass       => $config->{password},
+      -port       => $config->{port},
+      -db_version => $config->{db_version},
+      -no_cache   => $config->{no_slice_cache},
+    );
+  }
+  my $ha = $reg->get_adaptor( "multi", "compara", "homology" );
+
+  my $gene = $transcript->get_Gene;
+  my $protein = $transcript->translation->stable_id;
+
+  my $all_results = {};
+  my $homologies = $ha->fetch_all_by_Gene($gene, -METHOD_LINK_TYPE => 'ENSEMBL_PARALOGUES');
+  for my $homology (@$homologies) {
+    my $aln = $homology->get_SimpleAlign;
+
+    # identify paralogue protein
+    my @proteins = keys %{ $aln->{'_start_end_lists'} };
+    my $paralogue;
+    if ($protein eq $proteins[0]) {
+      $paralogue = $proteins[1];
+    } elsif ($protein eq $proteins[1]) {
+      $paralogue = $proteins[0];
+    } else {
+      next;
+    }
+
+    # get genomic coordinates from paralogue
+    my $col    = $aln->column_from_residue_number($protein, $pep_coords->start);
+    my $coords = $aln->get_seq_by_id($paralogue)->location_from_column($col);
+    next unless defined $coords and $coords->location_type eq 'EXACT';
+
+    my $para_tr       = $ta->fetch_by_stable_id($paralogue)->transcript;
+    my ($para_coords) = $para_tr->pep2genomic($coords->start, $coords->start);
+
+    my $chr   = $para_tr->seq_region_name;
+    my $start = $para_coords->start;
+    my $end   = $para_coords->end;
+
+    if (@{$self->{_files}}) {
+      # get variants from custom VCF file
+      my @data = @{$self->get_data($chr, $start - 2, $end)};
+      $all_results = $self->_join_results($all_results, $_) for @data;
+    } else {
+      # get Ensembl variants from mapped genomic coordinates
+      my $slice = $sa->fetch_by_region('chromosome', $chr, $start, $end);
+      foreach my $vf ( @{ $vfa->fetch_all_by_Slice($slice) } ) {
+        my $res = _summarise_vf($vf);
+        $all_results = $self->_join_results($all_results, $res);
+      }
+    }
+  }
+
+  return $all_results;
+}
+
+sub parse_data {
+  my ($self, $line) = @_;
+  my ($chrom, $start, $id, $ref, $alt, $qual, $filter, $info) = split /\t/, $line;
+
+  # VCF-like adjustment of mismatched substitutions for comparison with VEP
+  if(length($alt) != length($ref)) {
+    my $first_ref = substr($ref, 0, 1);
+    my $first_alt = substr($alt, 0, 1);
+    if ($first_ref eq $first_alt) {
+      $start++;
+      $ref = substr($ref, 1);
+      $alt = substr($alt, 1);
+      $ref ||= '-';
+      $alt ||= '-';
+    }
+  }
+
+  my $data = {
+    PARALOGUE_VARIANT_SEQNAME => $chrom,
+    PARALOGUE_VARIANT_START   => $start,
+    PARALOGUE_VARIANT_ID      => $id,
+    PARALOGUE_VARIANT_ALLELES => "$ref/$alt"
+  };
+
+  # include data from INFO fields
+  for my $field ( split /;/, $info ) {
+    my ($key, $value) = split /=/, $field;
+    $data->{'PARALOGUE_VARIANT_INFO_' . $key} = $value;
+  };
+  return $data;
+}
+
+sub get_start {
+  return $_[1]->{start};
+}
+
+sub get_end {
+  return $_[1]->{end};
+}
+
+1;

--- a/Paralogues.pm
+++ b/Paralogues.pm
@@ -92,7 +92,7 @@ sub _prepare_filename {
   # Prepare file name based on species, database version and assembly
   my $pkg      = __PACKAGE__.'.pm';
   my $species  = $config->{species};
-  my $version  = $config->{db_version} || 'Bio::ensembl::Registry'->software_version;
+  my $version  = $config->{db_version} || 'Bio::EnsEMBL::Registry'->software_version;
   my @name     = ($pkg, $species, $version);
 
   if( $species eq 'homo_sapiens' || $species eq 'human'){
@@ -473,9 +473,8 @@ sub new {
   if (defined $vcf) {
     $self->{vcf} = $vcf;
     $self->add_file($vcf);
-  } elsif ($config->{offline} || $config->{rest}) {
-    my $mode = $config->{rest} ? "REST" : "offline";
-    die("ERROR: Cannot fetch Ensembl variants in $mode mode; please define vcf argument in the Paralogues plugin\n");
+  } elsif ($config->{offline}) {
+    die("ERROR: Cannot fetch Ensembl variants in offline mode; please define vcf argument in the Paralogues plugin\n");
   }
 
   # Check if paralogue annotation should be downloaded

--- a/Paralogues.pm
+++ b/Paralogues.pm
@@ -406,8 +406,12 @@ sub _get_transcript_from_translation {
 
   # try to get transcript from cache
   if (defined $chr and defined $start and defined $strand) {
-    my $asa = Bio::EnsEMBL::VEP::AnnotationSourceAdaptor->new({config => $config});
-    my $as = $asa->get_all_from_cache->[0];
+    my $as = $self->{as};
+    if (!defined $as) {
+      # cache AnnotationSource
+      my $asa = Bio::EnsEMBL::VEP::AnnotationSourceAdaptor->new({config => $config});
+      $as = $self->{as} = $asa->get_all_from_cache->[0];
+    }
 
     my (@regions, $seen, $min_max, $min, $max);
     my $cache_region_size = $as->{cache_region_size};

--- a/Paralogues.pm
+++ b/Paralogues.pm
@@ -487,7 +487,6 @@ sub new {
     die "ERROR: directory $dir not found" unless -e -d $dir;
     $annot = File::Spec->catfile( $dir, $annot );
   }
-  warn Data::Dumper::Dumper $annot;
 
   $self->_generate_paralogue_annotation($annot) unless (-e $annot || -e "$annot.lock");
   $self->{paralogues} = $annot;

--- a/Paralogues.pm
+++ b/Paralogues.pm
@@ -50,6 +50,7 @@ limitations under the License.
  This plugin automatically downloads paralogue annotation from Ensembl databases
  if not available in the current directory (by default). Use argument `dir` to
  change the directory of the paralogue annotation:
+   --plugin Paralogues
    --plugin Paralogues,dir=/path/to/dir
 
  It is also possible to point to a custom tabix-indexed TSV file by using
@@ -65,8 +66,8 @@ limitations under the License.
    --plugin Paralogues,vcf=/path/to/file.vcf.gz
    --plugin Paralogues,vcf=/path/to/file.vcf.gz,cols=CLNSIG:CLNVI:GENEINFO
 
- To avoid downloading any data locally, the plugin also has a remote mode. The
- remote mode also supports fetching variants from a custom VCF file:
+ To avoid downloading data, the plugin has a remote mode. In the remote mode,
+ variants can also be fetched from the Ensembl API or a custom VCF:
    --plugin Paralogues,mode=remote
    --plugin Paralogues,mode=remote,vcf=/path/to/file.vcf.gz
    --plugin Paralogues,mode=remote,vcf=/path/to/file.vcf.gz,cols=CLNSIG:CLNVI:GENEINFO

--- a/plugin_config.txt
+++ b/plugin_config.txt
@@ -1109,6 +1109,21 @@ my $VEP_PLUGIN_CONFIG = {
       ]
     },
 
+    # Paralogues
+    {
+      "key" => "Paralogues",
+      "label" => "Variants in paralogue proteins",
+      "available" => 0,
+      "enabled" => 0,
+      "section" => "Pathogenicity predictions",
+      "helptip" => "Retrieves variants overlapping the genomic coordinates of amino acids aligned between paralogue proteins.",
+      "plugin_url" => "https://raw.githubusercontent.com/Ensembl/VEP_plugins/release/112/Paralogues.pm",
+      "requires_data" => 1,
+      "params" => [
+        #"/path/to/paralogue/annotation/dir"
+      ]
+    },
+
     ## SPLICING PREDICTIONS
     #######################
 


### PR DESCRIPTION
ENSVAR-2596

The Paralogues plugin fetches variants (from Ensembl API or custom VCF file) overlapping the genomic coordinates of amino acids aligned between paralogue proteins.

## Logic

To check for variants in paralogue, this plugin:
1. [Creates a tabix-indexed TSV file with paralogue annotation (translations only) from Ensembl API](https://github.com/nuno-agostinho/VEP_plugins/blob/f1d6008a91ef67284ed53684e3a2cde306131e20/Paralogues.pm#L461), like so:

```
#homology_id    chr     start   end     strand  stable_id       version perc_cov        perc_id perc_pos        cigar_line      paralogue_chr   paralogue_start paralogue_end   paralogue_strand        paralogue_stable_id     paralogue_version       paralogue_cigar_line
1755604 1       65419   71585   1       ENSP00000493376 2       93.5583 92.638  92.638  326M    19      107104  113156  1       ENSP00000467301 3       21D305M
1755605 1       65419   71585   1       ENSP00000493376 2       99.0798 97.8528 98.1595 326M    15      101922042       101923113       -1      ENSP00000497674 1       3D323M
1846785 1       65419   71585   1       ENSP00000493376 2       91.411  47.8528 67.1779 38MD203MD36M2D33MD4M5DM3D11M    11      55648327        55652854        1       ENSP00000493389 1       3M14D2MDMD18MD199MD40M2D30MD16M3D2M4D
1846962 1       65419   71585   1       ENSP00000493376 2       92.0245 45.092  67.4847 71MD170MD2M2D34M2D37M5DM2D11M   KI270727.1      372322  373405  1       ENSP00000484075 1       3M14D52MD170MD42M2D43MD3M7D
1846965 1       65419   71585   1       ENSP00000493376 2       92.0245 45.092  67.1779 71MD170MD2M2D34M2D37M5DM2D11M   15      22080527        22081610        1       ENSP00000483239 3       3M14D52MD170MD42M2D43MD3M7D
1846968 1       65419   71585   1       ENSP00000493376 2       92.0245 44.7853 67.1779 71MD170MD2M2D34M2D37M5DM2D11M   15      21637909        21638992        1       ENSP00000329467 3       3M14D52MD170MD42M2D43MD3M7D
1846971 1       65419   71585   1       ENSP00000493376 2       92.0245 46.319  69.3252 71MD170MD2M2D34M2D37M5DM2D11M   14      19773504        19783696        1       ENSP00000492985 1       3M14D52MD170MD42M2D43MD3M7D
1847414 1       65419   71585   1       ENSP00000493376 2       81.9018 33.1288 50.3067 2MD19MD17M3D3MD2MD77M2D5MD21MD19MD11MD10MD20MD7M3D5MD5M2D14MDMD4M2D24M2D3MD8M2D4MD2M3D27MD4M7DM6D11M    1       158716327       158720720       -1      ENSP00000357127 2       4M15D4MD9M3D8MD9MD70M2D8MD22MD16MD10MD13MD20M2D3MD5M2D5MD4M2D11MD4MDMD28M3D7MD3MD4M2D29MD4MD14M11D
1847538 1       65419   71585   1       ENSP00000493376 2       90.1841 42.9448 62.2699 38MD203MD36M2D33MD4M6DM4D11M    11      49981473        49982535        -1      ENSP00000334418 4       3M14D2MDMD18MD199MD40M2D30MD11MD4MDM9D
1847661 1       65419   71585   1       ENSP00000493376 2       83.7423 34.3558 54.2945 18D2MD18MDMD17MD5MD3MD74MD5MD40MD8MD14M2D23MD3MD5MD5M2D14MDMD4M2D6MD18M2D3MD8M3D6MD2MD25MD4M5DM12D11M   19      9250930 9252625 1       ENSP00000387523 3       22M15DMD3MD18MD2MD6MD70MD8MD38MD11MD9MDMD22MD8M2D3MDMD17MD4MDMD7MD21M2D2MD3M3D38MD23M11D
```

2. For each variant, it will check if the translation is in the paralogue annotation.
3. If annotated as having a paralogue, [the plugin creates an array of `Bio::SimpleAlign` objects for each paralogue](https://github.com/nuno-agostinho/VEP_plugins/blob/f1d6008a91ef67284ed53684e3a2cde306131e20/Paralogues.pm#L324-L325).
    - [The genomic location of the paralogue is included in the object](https://github.com/nuno-agostinho/VEP_plugins/blob/f1d6008a91ef67284ed53684e3a2cde306131e20/Paralogues.pm#L288-L292) for faster retrieval of protein info from cache later on.
4. For each paralogue, [we calculate the genomic coordinates of the aligned aminoacid between the two proteins](https://github.com/nuno-agostinho/VEP_plugins/blob/f1d6008a91ef67284ed53684e3a2cde306131e20/Paralogues.pm#L353-L369).
    - The paralogue information is [retrieved from cache (if possible)](https://github.com/nuno-agostinho/VEP_plugins/blob/f1d6008a91ef67284ed53684e3a2cde306131e20/Paralogues.pm#L387-L416).
    - If cache is not available, the paralogue information is [fetched from the Ensembl API](https://github.com/nuno-agostinho/VEP_plugins/blob/f1d6008a91ef67284ed53684e3a2cde306131e20/Paralogues.pm#L424-L430).
5. The plugin [fetches variants overlapping the genomic coordinates of the paralogue's affected aminoacid](https://github.com/nuno-agostinho/VEP_plugins/blob/f1d6008a91ef67284ed53684e3a2cde306131e20/Paralogues.pm#L552-L570) from one of two sources:
    - Custom VCF based on `vcf` parameter
    - Ensembl API (if `vcf` parameter is not defined)

### Remote mode

The plugin also supports a `mode=remote` mode where it directly fetches the homologies from Ensembl API (potentially faster for a small amount of variants). This mode can be removed if we think it serves no purpose.

### Questions

- Should we allow to filter annotated variants based on pathogenicity? For instance, only return results for pathogenic variants?
- Should we include transcript paralogues? I think most are non-coding, so this may not be priority and may be included in a future PR.
- When using a custom VCF, we only require protein information that is available in cache. However, when `--cache` is enabled, the plugin is an order of magnitude slower than with `--offline` enabled (probably still tying to communicate with database in `--cache` mode). Is there a way to read from cache without connecting to database at all? Probably related with adaptors.
- Currently, the plugin is only using the start position of any variant to fetch paralogue variants: should we limit the plugin for small variants or even specific categories (like missense)? Otherwise, it could be slow when fetching variants for large regions.

## Testing

Examples of variants to test with this plugin:

```
1	939112	.	G	A
1	44827194-44827195	.	GT	AA
1	8871910	.	C	T
2	166073606	.	G	T
17	4833586	.	G	T
```

Some use cases to test:
1. Test the plugin with no parameters.
    - First run should download the paralogue annotation and then annotate variants as expected.
    - Second run should just use the annotation in the current directory to annotate the variants.
3. Test with specific `dir` and `paralogues` parameters. The plugin should download the file to a given directory (`dir`) with the given filename (`prologues`) if it doesn't exist.
4. Test with a custom VCF file: you can use the ClinVar VCF.
5. Test if the `mode=remote` works with and without a custom VCF file.