### PR TITLE
Add SpliceVault plugin

### DIFF
--- a/SpliceVault.pm
+++ b/SpliceVault.pm
@@ -105,9 +105,9 @@ sub feature_types {
 
 sub get_header_info {
   return {
-    'SPLICEVAULT_SAMPLE_COUNT' => 'Number of SpliceVault annotated splicing samples',
-    'SPLICEVAULT_OUT_OF_FRAME_EVENTS' => 'Number of top SpliceVault events that are out of frame',
-    'SPLICEVAULT_TOP*_EVENT' => 'SpliceVault top events with the following colon-separated fields: type:description:percent_of_supporting_samples:event_frame',
+    'SpliceVault_sample_count' => 'Number of SpliceVault annotated splicing samples',
+    'SpliceVault_out_of_frame_events' => 'Number of top SpliceVault events that are out of frame',
+    'SpliceVault_top*_event' => 'SpliceVault top events with the following colon-separated fields: type:description:percent_of_supporting_samples:event_frame',
   }
 }
 
@@ -160,8 +160,8 @@ sub parse_data {
   my $res = {
     feature => $feature,
     result  => {
-      SPLICEVAULT_SAMPLE_COUNT        => $count,
-      SPLICEVAULT_OUT_OF_FRAME_EVENTS => $out_of_frame,
+      SpliceVault_sample_count        => $count,
+      SpliceVault_out_of_frame_events => $out_of_frame,
     }
   };
 
@@ -177,7 +177,7 @@ sub parse_data {
     } elsif ($event =~ /^CD/) {
       $event =~ s/^CD/cryptic_donor/g;
     }
-    $res->{result}->{"SPLICEVAULT_TOP${n}_EVENT"} = $event;
+    $res->{result}->{"SpliceVault_top${n}_event"} = $event;
   }
   return $res;
 }

--- a/SpliceVault.pm
+++ b/SpliceVault.pm
@@ -29,7 +29,7 @@ limitations under the License.
 
  mv SpliceVault.pm ~/.vep/Plugins
 
- ./vep -i variations.vcf --plugin SpliceVault,file=/path/to/SpliceVault_data.tsv.gz
+ ./vep -i variations.vcf --plugin SpliceVault,file=/path/to/SpliceVault_data_GRCh38.tsv.gz
 
  # Stringently select predicted loss-of-function (pLoF) splicing variants
  ./filter_vep -i variant_effect_output.txt --filter "SPLICEVAULT_OUT_OF_FRAME_EVENTS >= 3"
@@ -71,8 +71,9 @@ limitations under the License.
  resource: https://pubmed.ncbi.nlm.nih.gov/36747048
 
  The tabix utility must be installed in your path to use this plugin. The
- SpliceVault TSV and respective index (TBI) for GRCh38 can be downloaded from
- https://ftp.ensembl.org/pub/current_variation/SpliceVault/SpliceVault_data.tsv.gz
+ SpliceVault TSV and respective index (TBI) for GRCh38 can be downloaded from:
+ - https://ftp.ensembl.org/pub/current_variation/SpliceVault/SpliceVault_data_GRCh38.tsv.gz
+ - https://ftp.ensembl.org/pub/current_variation/SpliceVault/SpliceVault_data_GRCh38.tsv.gz.tbi
 
  To filter results, please use filter_vep with the output file or standard
  output. Documentation on filter_vep is available at:

--- a/SpliceVault.pm
+++ b/SpliceVault.pm
@@ -40,19 +40,34 @@ limitations under the License.
  and activated cryptic splice sites based on the most common mis-splicing events
  around a splice site.
 
- This plugin returns the most common (top 4) variant-associated mis-splicing
- events for variants that overlap a near-splice-site region (-17:+3 for splice
- acceptor sites and -3:+8 for splice donor sites) based on SpliceVault data.
- Each event includes the following information:
-   - Type: exon skipping (ES), cryptic donor (CD) or cryptic acceptor (CA)
-   - Description: exons skiped (ES events) or cryptic distance to the annotated
-     splice site (CD/CA events)
-   - Percent of supporting samples: samples supporting the event over total
-     samples where splicing occurs in that site (in percentage)
-   - Frameshift: inframe or out-of-frame event
+ This plugin returns the most common variant-associated mis-splicing events
+ based on SpliceVault data. Each event includes the following information:
+ - Type: exon skipping (ES), cryptic donor (CD) or cryptic acceptor (CA)
+ - Transcript impact:
+   - For ES, describes skipped exons, e.g. ES:2 represents exon 2 skipping and
+     ES:2-3 represents skipping of exon 2 and 3
+   - For CD/CA, describes the distance from the annotated splice-site to the
+     cryptic splice-site with reference to the transcript (distances to negative
+     strand transcripts are reported according to the 5' to 3' distance)
+ - Percent of supporting samples: percent of samples supporting the event over
+   total samples where splicing occurs in that site (note this may be above 100%
+   if the event is seen in more samples than annotated splicing)
+ - Frameshift: inframe or out-of-frame event
+
+ The plugin also returns information specific to each splice site:
+ - Site position/type: genomic location and type (donor/acceptor) of the
+   splice-site predicted to be lost by SpliceAI. Cryptic positions are relative
+   to this genomic coordinate.
+ - Out of frame events: fraction of the top events that cause a frameshift. As
+   per https://pubmed.ncbi.nlm.nih.gov/36747048, sites with 3/4 or more in-frame
+   events are likely to be splice-rescued and not loss-of-function (LoF).
+ - Site sample count and max depth: sample count for this splice site and max
+   number of reads in any single sample representing annotated splicing in
+   Genotype-Tissue Expression (GTEx). This information allows to filter events
+   based on a minimum number of samples or minimum depth in GTEx.
 
  Please cite the SpliceVault publication alongside the VEP if you use this
- resource: https://pubmed.ncbi.nlm.nih.gov/36747048/
+ resource: https://pubmed.ncbi.nlm.nih.gov/36747048
 
  The tabix utility must be installed in your path to use this plugin. The
  SpliceVault TSV and respective index (TBI) for GRCh38 can be downloaded from
@@ -108,7 +123,7 @@ sub get_header_info {
     SpliceVault_top_events          => 'List of SpliceVault top events with the following colon-separated fields per event: rank:type:transcript_impact:percent_of_supporting_samples:frame',
     SpliceVault_site_sample_count   => 'Number of SpliceVault annotated splicing samples',
     SpliceVault_site_max_depth      => 'Maximum number of reads seen in any one sample representing annotated splicing in GTEx',
-    SpliceVault_out_of_frame_events => 'Fraction of SpliceVault top events that cause a frameshift; as per SpliceVault article, sites with 3/4 or more in-frame events are likely to be splice-rescued and not LoF',
+    SpliceVault_out_of_frame_events => 'Fraction of SpliceVault top events that cause a frameshift',
     SpliceVault_site_pos            => 'Genomic position of splice-site predicted to be lost by SpliceAI',
     SpliceVault_site_type           => 'Type of splice-site predicted to be lost by SpliceAI',
   }

--- a/SpliceVault.pm
+++ b/SpliceVault.pm
@@ -31,7 +31,7 @@ limitations under the License.
 
  ./vep -i variations.vcf --plugin SpliceVault,file=/path/to/SpliceVault_data.tsv.gz
 
- # Stringely select predicted loss-of-function (pLoF) splicing variants
+ # Stringently select predicted loss-of-function (pLoF) splicing variants
  ./filter_vep -i variant_effect_output.txt --filter "SPLICEVAULT_OUT_OF_FRAME_EVENTS >= 3"
 
 =head1 DESCRIPTION
@@ -108,7 +108,7 @@ sub new {
   }
 
   die "ERROR: add Tabix-indexed file, for example:\n" .
-    "  --plugin SpliceVault,file=/path/to/SpliceVault_data.tsv.gz \n"
+    "  --plugin SpliceVault,file=/path/to/SpliceVault_data_GRCh38.tsv.gz \n"
     unless @files > 0;
   $self->add_file($_) for @files;
 

--- a/SpliceVault.pm
+++ b/SpliceVault.pm
@@ -1,0 +1,197 @@
+=head1 LICENSE
+
+Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
+Copyright [2016-2023] EMBL-European Bioinformatics Institute
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=head1 CONTACT
+
+ Ensembl <http://www.ensembl.org/info/about/contact/index.html>
+    
+=cut
+
+=head1 NAME
+
+ SpliceVault
+
+=head1 SYNOPSIS
+
+ mv SpliceVault.pm ~/.vep/Plugins
+
+ ./vep -i variations.vcf --plugin SpliceVault,file=/path/to/SpliceVault_data.tsv.gz
+
+ # Stringely select predicted loss-of-function (pLoF) splicing variants
+ ./filter_vep -i variant_effect_output.txt --filter "SPLICEVAULT_OUT_OF_FRAME_EVENTS >= 3"
+
+=head1 DESCRIPTION
+
+ A VEP plugin that retrieves SpliceVault data to predict exon-skipping events
+ and activated cryptic splice sites based on the most common mis-splicing events
+ around a splice site.
+
+ This plugin returns the most common (top 4) variant-associated mis-splicing
+ events for variants that overlap a near-splice-site region (-17:+3 for splice
+ acceptor sites and -3:+8 for splice donor sites) based on SpliceVault data.
+ Each event includes the following information:
+   - Type: exon skipping (ES), cryptic donor (CD) or cryptic acceptor (CA)
+   - Description: exons skiped (ES events) or cryptic distance to the annotated
+     splice site (CD/CA events)
+   - Percent of supporting samples: samples supporting the event over total
+     samples where splicing occurs in that site (in percentage)
+   - Frameshift: inframe or out-of-frame event
+
+ Please cite the SpliceVault publication alongside the VEP if you use this
+ resource: https://pubmed.ncbi.nlm.nih.gov/36747048/
+
+ The tabix utility must be installed in your path to use this plugin. The
+ SpliceVault TSV and respective index (TBI) for GRCh38 can be downloaded from
+ https://ftp.ensembl.org/pub/current_variation/SpliceVault/SpliceVault_data.tsv.gz
+
+ To filter results, please use filter_vep with the output file or standard
+ output. Documentation on filter_vep is available at:
+ https://www.ensembl.org/info/docs/tools/vep/script/vep_filter.html
+
+=cut
+
+package SpliceVault;
+
+use strict;
+use warnings;
+
+use Bio::EnsEMBL::Utils::Sequence qw(reverse_comp);
+use Bio::EnsEMBL::Variation::Utils::Sequence qw(get_matched_variant_alleles);
+
+use Bio::EnsEMBL::Variation::Utils::BaseVepTabixPlugin;
+use base qw(Bio::EnsEMBL::Variation::Utils::BaseVepTabixPlugin);
+
+sub new {
+  my $class = shift;  
+  my $self = $class->SUPER::new(@_);
+
+  $self->expand_left(0);
+  $self->expand_right(0);
+  $self->get_user_params();
+  
+  # Check files in arguments
+  my @files; 
+  my $params = $self->params_to_hash();
+
+  for my $key (keys %{$params}) {
+    push @files, $params->{$key};
+  }
+
+  die "ERROR: add Tabix-indexed file, for example:\n" .
+    "  --plugin SpliceVault,file=/path/to/SpliceVault_data.tsv.gz \n"
+    unless @files > 0;
+  $self->add_file($_) for @files;
+
+  return $self;
+}
+
+sub feature_types {
+  return ['Transcript'];
+}
+
+sub get_header_info {
+  return {
+    'SPLICEVAULT_START' => 'SpliceVault splice region start',
+    'SPLICEVAULT_END'   => 'SpliceVault splice region end',
+    'SPLICEVAULT_SAMPLE_COUNT' => 'Number of SpliceVault annotated splicing samples',
+    'SPLICEVAULT_OUT_OF_FRAME_EVENTS' => 'Number of top SpliceVault events that are out of frame',
+    'SPLICEVAULT_TOP*_EVENT' => 'SpliceVault top events with the following colon-separated fields: type:description:percent_of_supporting_samples:event_frame',
+  }
+}
+
+sub _join_results {
+  my $self = shift;
+  my $all_results = shift;
+  my $res = shift;
+
+  if ($self->{config}->{output_format} eq 'json' || $self->{config}->{rest}) {
+    for (keys %$res) {
+      next unless $_ =~ /TOP[0-9]+_EVENT/;
+      my @fields = split /:/, $res->{$_};
+      delete $res->{$_};
+      $res->{$_}->{'TYPE'} = $fields[0];
+      $res->{$_}->{'DESCRIPTION'} = $fields[1];
+      $res->{$_}->{'PERCENT_OF_SUPPORTING_SAMPLES'} = $fields[2];
+      $res->{$_}->{'FRAMESHIFT'} = $fields[3];
+    }
+    # Group results for JSON and REST
+    $all_results->{"SpliceVault"} = [] unless defined $all_results->{"SpliceVault"};
+    push(@{ $all_results->{"SpliceVault"} }, $res);
+  } else {
+    # Create array of results per key
+    for (keys %$res) {
+      $all_results->{$_} = [] if !$all_results->{$_};
+      push(@{ $all_results->{$_} }, $res->{$_} || "NA");
+    }
+  }
+  return $all_results;
+}
+
+sub run {
+  my ($self, $tva) = @_;
+
+  my $vf = $tva->variation_feature;
+  my @data = @{ $self->get_data($vf->{chr}, $vf->{start} - 2, $vf->{end}) };
+
+  my $all = {};
+  foreach (@data) {
+    next unless $tva->transcript->stable_id eq $_->{feature};
+    $all = $self->_join_results($all, $_->{result});
+  }
+  return $all;
+}
+
+sub parse_data {
+  my ($self, $line) = @_;
+  my ($feature, $chrom, $start, $end, $count, $out_of_frame, @top_events) = split /\t/, $line;
+
+  my $res = {
+    feature => $feature,
+    result  => {
+      SPLICEVAULT_START               => $start,
+      SPLICEVAULT_END                 => $end,
+      SPLICEVAULT_SAMPLE_COUNT        => $count,
+      SPLICEVAULT_OUT_OF_FRAME_EVENTS => $out_of_frame,
+    }
+  };
+
+  my $n = 0;
+  for my $event (@top_events) {
+    $n++;
+    $event =~ s/;/:/g;
+    
+    if ($event =~ /^ES/) {
+      $event =~ s/^ES/exon_skipping/g;
+    } elsif ($event =~ /^CA/) {
+      $event =~ s/^CA/cryptic_acceptor/g;
+    } elsif ($event =~ /^CD/) {
+      $event =~ s/^CD/cryptic_donor/g;
+    }
+    $res->{result}->{"SPLICEVAULT_TOP${n}_EVENT"} = $event;
+  }
+  return $res;
+}
+
+sub get_start {
+  return $_[1]->{start};
+}
+
+sub get_end {
+  return $_[1]->{end};
+}
+
+1;

--- a/SpliceVault.pm
+++ b/SpliceVault.pm
@@ -65,6 +65,7 @@ limitations under the License.
    number of reads in any single sample representing annotated splicing in
    Genotype-Tissue Expression (GTEx). This information allows to filter events
    based on a minimum number of samples or minimum depth in GTEx.
+ - SpliceAI delta score (provided by SpliceVault)
 
  Please cite the SpliceVault publication alongside the VEP if you use this
  resource: https://pubmed.ncbi.nlm.nih.gov/36747048
@@ -126,6 +127,7 @@ sub get_header_info {
     SpliceVault_out_of_frame_events => 'Fraction of SpliceVault top events that cause a frameshift',
     SpliceVault_site_pos            => 'Genomic position of splice-site predicted to be lost by SpliceAI',
     SpliceVault_site_type           => 'Type of splice-site predicted to be lost by SpliceAI',
+    SpliceVault_SpliceAI_delta      => 'SpliceVault-provided SpliceAI delta score'
   }
 }
 
@@ -148,7 +150,7 @@ sub run {
         strand => $vf->strand
       },
       {
-       ref  => $vf->ref_allele_string,
+       ref  => $_->{ref},
        alts => [$_->{alt}],
        pos  => $_->{start},
       }
@@ -176,18 +178,20 @@ sub run {
 
 sub parse_data {
   my ($self, $line) = @_;
-  my ($chrom, $start, $alt, $feature, $type, $site, $out_of_frame, $top_events, $count, $max_depth) = split /\t/, $line;
+  my ($chrom, $start, $ref, $alt, $feature, $type, $site, $spliceAI_delta, $out_of_frame, $top_events, $count, $max_depth) = split /\t/, $line;
 
   $top_events =~ s/ /_/g;
   $top_events =~ s/;/:/g;
 
   my $res = {
     feature => $feature,
+    ref     => $ref,
     alt     => $alt,
     start   => $start,
     result  => {
       SpliceVault_site_sample_count   => $count,
       SpliceVault_site_max_depth      => $max_depth,
+      SpliceVault_SpliceAI_delta      => $spliceAI_delta,
       SpliceVault_out_of_frame_events => $out_of_frame,
       SpliceVault_top_events          => [ split(/\|/, $top_events) ],
       SpliceVault_site_pos            => $site,

--- a/SpliceVault.pm
+++ b/SpliceVault.pm
@@ -105,8 +105,6 @@ sub feature_types {
 
 sub get_header_info {
   return {
-    'SPLICEVAULT_START' => 'SpliceVault splice region start',
-    'SPLICEVAULT_END'   => 'SpliceVault splice region end',
     'SPLICEVAULT_SAMPLE_COUNT' => 'Number of SpliceVault annotated splicing samples',
     'SPLICEVAULT_OUT_OF_FRAME_EVENTS' => 'Number of top SpliceVault events that are out of frame',
     'SPLICEVAULT_TOP*_EVENT' => 'SpliceVault top events with the following colon-separated fields: type:description:percent_of_supporting_samples:event_frame',
@@ -162,8 +160,6 @@ sub parse_data {
   my $res = {
     feature => $feature,
     result  => {
-      SPLICEVAULT_START               => $start,
-      SPLICEVAULT_END                 => $end,
       SPLICEVAULT_SAMPLE_COUNT        => $count,
       SPLICEVAULT_OUT_OF_FRAME_EVENTS => $out_of_frame,
     }

--- a/plugin_config.txt
+++ b/plugin_config.txt
@@ -1227,7 +1227,7 @@ my $VEP_PLUGIN_CONFIG = {
     # SpliceVault
     {
       "key" => "SpliceVault",
-      "label" => "SpliceVaul",
+      "label" => "SpliceVault",
       "helptip" => "Retrieves the most common variant-associated mis-splicing events for variants that overlap a near-splice-site region",
       "available" => 0,
       "enabled" => 0,

--- a/plugin_config.txt
+++ b/plugin_config.txt
@@ -1224,6 +1224,16 @@ my $VEP_PLUGIN_CONFIG = {
       ],
     },
 
+    # SpliceVault
+    {
+      "key" => "SpliceVault",
+      "label" => "SpliceVaul",
+      "helptip" => "Retrieves the most common variant-associated mis-splicing events for variants that overlap a near-splice-site region",
+      "available" => 0,
+      "enabled" => 0,
+      "section" => "Splicing predictions",
+      "plugin_url" => "https://raw.githubusercontent.com/Ensembl/VEP_plugins/release/112/SpliceVault.pm",
+    },
 
 
     ## CONSERVATION


### PR DESCRIPTION
ENSVAR-6077: SpliceVault predicts the precise nature of variant-associated mis-splicing

Please read the plugin description and check if its usage is clear. If not, ask me to improve it, thanks

- [x] TODO: Update with URL for data download

## Testing

**[UPDATED ON 28 NOV]** File path to SpliceVault data available in ENSVAR-6077

Example variants:

```
4 53458 . C G
8 232267 . G A
11 193107 . G T
14 18972751 . C G
20 95995 . T G
X 2789641 . C A
Y 2841627 . G C
```

<details><summary>Old example variants (older data)</summary>
<p>

```
4 59554 . T G
8 78907 . G A
11 1887471 . C T
14 18412137 . A G
20 145581 . A T
X 281484 . A G
Y 2787482 . T C
```

</p>
</details> 

Command-line example:

```
vep -i input.txt --plugin SpliceVault,file=splicevault_data.tsv.gz
```