### PR TITLE
Add original author text for UTRannotator

### DIFF
--- a/PostGAP.pm
+++ b/PostGAP.pm
@@ -17,11 +17,7 @@ limitations under the License.
 
 =head1 CONTACT
 
-Please email comments or questions to the public Ensembl
-developers list at <https://lists.ensembl.org/mailman/listinfo/dev>.
-
-Questions may also be sent to the Ensembl helpdesk at
-<https://www.ensembl.org/Help/Contact>.
+  Ensembl <https://www.ensembl.org/info/about/contact/index.html>
     
 =cut
 

--- a/UTRAnnotator.pm
+++ b/UTRAnnotator.pm
@@ -15,6 +15,7 @@ limitations under the License.
 =head1 CONTACT
 
     Ensembl <http://www.ensembl.org/info/about/contact/index.html>
+    Xiaolei Zhang <xiaolei@ebi.ac.uk>
 
 =cut
 

--- a/UTRAnnotator.pm
+++ b/UTRAnnotator.pm
@@ -46,6 +46,11 @@ limitations under the License.
 
     About UTRAnnotator:
 
+    The original UTRAnnotator plugin is written by Xiaolei Zhang et al. Later adopted by Ensembl VEP plugins with some changes.
+    You can find the original plugin here -
+    https://github.com/ImperialCardioGenetics/UTRannotator 
+
+    Please cite the UTRannotator publication alongside the Ensembl VEP if you use this resource -
     Annotating high-impact 5'untranslated region variants with the UTRannotator Zhang, X., Wakeling, M.N., Ware, J.S, Whiffin, N. Bioinformatics; doi: https://academic.oup.com/bioinformatics/advance-article/doi/10.1093/bioinformatics/btaa783/5905476
 
 =cut

--- a/UTRAnnotator.pm
+++ b/UTRAnnotator.pm
@@ -14,7 +14,7 @@ limitations under the License.
 
 =head1 CONTACT
 
-    Xiaolei Zhang <xiaolei@ebi.ac.uk>
+    Xiaolei Zhang
     Ensembl <http://www.ensembl.org/info/about/contact/index.html>
 
 =cut

--- a/UTRAnnotator.pm
+++ b/UTRAnnotator.pm
@@ -14,8 +14,8 @@ limitations under the License.
 
 =head1 CONTACT
 
-    Ensembl <http://www.ensembl.org/info/about/contact/index.html>
     Xiaolei Zhang <xiaolei@ebi.ac.uk>
+    Ensembl <http://www.ensembl.org/info/about/contact/index.html>
 
 =cut
 

--- a/pLI.pm
+++ b/pLI.pm
@@ -17,11 +17,7 @@ limitations under the License.
 
 =head1 CONTACT
 
- Please email comments or questions to the public Ensembl
- developers list at <https://lists.ensembl.org/mailman/listinfo/dev>.
-
- Questions may also be sent to the Ensembl helpdesk at
- <https://www.ensembl.org/Help/Contact>.
+  Ensembl <https://www.ensembl.org/info/about/contact/index.html>
 
 =cut
 

--- a/satMutMPRA.pm
+++ b/satMutMPRA.pm
@@ -17,11 +17,7 @@ limitations under the License.
 
 =head1 CONTACT
 
-Please email comments or questions to the public Ensembl
-developers list at <https://lists.ensembl.org/mailman/listinfo/dev>.
-
-Questions may also be sent to the Ensembl helpdesk at
-<https://www.ensembl.org/Help/Contact>.
+  Ensembl <https://www.ensembl.org/info/about/contact/index.html>
 
 =cut
 


### PR DESCRIPTION
Sister PR in public plugins - https://github.com/Ensembl/public-plugins/pull/738

Updated some plugins Ensembl contact to match `author <email>` as doc generation script expects.