### PR TITLE
Avoid AlphaMissense smartmatch

### DIFF
--- a/AlphaMissense.pm
+++ b/AlphaMissense.pm
@@ -151,9 +151,14 @@ sub _parse_colnames {
     $self->{cols} = \@cols;
 
     # Check validity of all columns
-    my @invalid_cols = grep { !($_ ~~ $self->{colnames}) } @cols;
-    die "\n  ERROR: The following columns were not found in file header: ",
-      join(", ", @invalid_cols), "\n" if @invalid_cols;
+    my @invalid_cols;
+    for my $col (@{ $self->{cols} }) {
+      push(@invalid_cols, $col) unless grep(/^$col$/, @{ $self->{colnames} });
+    }
+
+    die "\n\n  The following columns were not found in file header: ",
+      join(", ", @invalid_cols), "\n\n  Valid columns are: " .
+      join(", ", @{ $self->{colnames} }) . "\n" if @invalid_cols;
   }
 }
 


### PR DESCRIPTION
## Changelog

- Avoid smartmatch
- List valid columns on invalid input

## Testing

- No smartwatch warning when using plugin with newer Perl versions:

  ```
  vep --id rs201106962 --database --force \
      --plugin AlphaMissense,file=AlphaMissense_hg38.tsv.gz,cols=am_genome:am_class
  ```

- Print list of available columns when asking for an invalid column:

  ```
  vep --id rs201106962 --database --force \
      --plugin AlphaMissense,file=AlphaMissense_hg38.tsv.gz,cols=am_genome:am_class:am_invalid_col
  ```