### PR TITLE
Avoid annotating SVs with short variant-associated phenotypes

### DIFF
--- a/Phenotypes.pm
+++ b/Phenotypes.pm
@@ -137,8 +137,6 @@ sub new {
   my $params_hash = $self->params_to_hash();
   $CONFIG{$_} = $params_hash->{$_} for keys %$params_hash;
 
-  die("ERROR: File not found (".$CONFIG{file}.") and unable to generate GFF file in offline mode\n") if $self->{config}{offline} && ($CONFIG{file} && !-e $CONFIG{file}) ;
-
   #for REST calls report all data (use json output flag)
   $self->{config}->{output_format} ||= $CONFIG{output_format};
 
@@ -153,9 +151,6 @@ sub new {
   $refresh = 1 if (exists $CONFIG{species} && $CONFIG{species} ne $self->{config}{species});
 
   unless($CONFIG{file} && !$refresh) {
-
-    die("ERROR: Unable to generate GFF file in offline mode\n") if $self->{config}->{offline};
-
     my $pkg = __PACKAGE__;
     $pkg .= '.pm';
 
@@ -208,7 +203,7 @@ sub generate_phenotype_gff {
   my ($self, $file) = @_;
 
   my $config = $self->{config};
-  die("ERROR: Unable to generate GFF file in offline mode\n") if $config->{offline};
+  die("ERROR: File not found (".$file.") and unable to generate GFF file in offline mode\n") if $config->{offline};
   die("ERROR: Not allowed to generate GFF file in rest mode\n") if $config->{rest};
   
   # test bgzip

--- a/Phenotypes.pm
+++ b/Phenotypes.pm
@@ -28,7 +28,21 @@ Phenotypes
 =head1 SYNOPSIS
 
  mv Phenotypes.pm ~/.vep/Plugins
+
+ # Automatically download phenotype annotation files if needed and annotate
+ # variants with phenotypes
  ./vep -i variations.vcf --plugin Phenotypes
+
+ # Fetch only gene-associated phenotypes
+ ./vep -i variations.vcf --plugin Phenotypes,include_types=Gene
+
+ # Set directory with phenotypes annotations (phenotype annotation file is
+ # automatically downloaded if not available in this directory)
+ ./vep -i variations.vcf --plugin Phenotypes,dir=${HOME},include_types=Gene
+
+ # Specify a file with phenotypes annotation (file is automatically
+ # downloaded and saved with this name if it does not exist)
+ ./vep -i variations.vcf --plugin Phenotypes,file=${HOME}/phenotypes.gff.gz,include_types=Gene
 
 =head1 DESCRIPTION
 
@@ -49,33 +63,39 @@ Phenotypes
 
  Several paramters can be set using a key=value system:
 
- dir            : provide a dir path, where either to create anew the species
-                  specific file from the download or to look for an existing file
+ dir            : Path to directory where to look for phenotypes annotation. If
+                  the required file does not exist, the file is downloaded and
+                  saved in the provided directory (download requires using
+                  database or cache mode).
 
- file           : provide a file path, either to create anew from the download
-                  or to point to an existing file
+ file           : File path to phenotypes annotation. If the file does
+                  not exist, the file is downloaded and saved with this name
+                  (download requires using database or cache mode).
 
- exclude_sources: exclude sources of phenotype information. By default
-                  HGMD and COSMIC annotations are excluded. See
+ exclude_sources: &-separated list of phenotype sources to exclude. By default,
+                  HGMD-PUBLIC and COSMIC annotations are excluded. See
                   http://www.ensembl.org/info/genome/variation/phenotype/sources_phenotype_documentation.html
-                  Separate multiple values with '&'
 
- include_sources: force include sources, as exclude_sources
+ include_sources: &-separated list of phenotype sources to include. If defined,
+                  exclude_sources is ignored.
 
- exclude_types  : exclude types of features. By default StructuralVariation
-                  and SupportingStructuralVariation annotations are excluded
-                  due to their size. Separate multiple values with '&'.
-                  Valid types: Gene, Variation, QTL, StructuralVariation,
-                  SupportingStructuralVariation, RegulatoryFeature
+ exclude_types  : &-separated list of feature types to exclude: Gene, Variation,
+                  QTL, StructuralVariation, SupportingStructuralVariation,
+                  RegulatoryFeature. By default, StructuralVariation and 
+                  SupportingStructuralVariation annotations are always excluded
+                  (due to size issues) and Variation is excluded when annotating
+                  structural variants; to get these annotations in all cases, use
+                  include_types=StructuralVariation&SupportingStructuralVariation&Variation
 
- include_types  : force include types, as exclude_types
+ include_types  : &-separated list of feature types to include. If defined,
+                  exclude_types is ignored.
 
- expand_right   : sets cache size in bp. By default annotations 100000bp (100kb)
-                  downstream of the initial lookup are cached
+ expand_right   : Cache size in bp. By default, annotations 100000bp (100kb)
+                  downstream of the initial lookup are cached.
 
- phenotype_feature : report the specific gene or variation the phenotype is
-                  linked to, this can be an overlapping gene or structural variation,
-                  and the source of the annotation (default 0)
+ phenotype_feature : Boolean to report the gene/variation associated with the
+                     phenotype (such as overlapping gene or structural
+                     variation) and annotation source (default: 0)
 
  Example:
 

--- a/Phenotypes.pm
+++ b/Phenotypes.pm
@@ -287,7 +287,8 @@ sub run {
   my ($self, $bvfo) = @_;
   
   my $vf = $bvfo->base_variation_feature;
-  
+  $self->{is_sv} = $vf->isa('Bio::EnsEMBL::Variation::StructuralVariationFeature');
+
   # adjust coords for tabix
   my ($s, $e) = ($vf->{start}, $vf->{end});
   ($s, $e) = ($vf->{end}, $vf->{start}) if ($vf->{start} > $vf->{end}); # swap for insertions
@@ -361,7 +362,11 @@ sub parse_data {
     return undef if $data->{type} && !$inc_types->{$data->{type}};
   }
   else {
-    return undef if $data->{type} && $self->exclude_types->{$data->{type}};
+    return undef if $data->{type} && (
+                      $self->exclude_types->{$data->{type}} ||
+                      # avoid annotating SVs with short variant-associated phenotypes
+                      ($self->{is_sv} && $data->{type} eq 'Variation')
+                    );
   }
 
   # parse attributes


### PR DESCRIPTION
ENSVAR-3780: Avoid web VEP throwing error when using phenotypes on big SV

## Motivation

The SV `13 32307062 sv1 . <DEL> . . SVTYPE=DEL;END=32908738` was being annotated with 30k short variant-associated phenotypes for each transcript-variant pair, making the file too big to be handled by web VEP.

This coupled with using `--regulatory` in web VEP (default) would return the following crash error message, given that it would increase even more the big number of phenotypes in the file:

```
-------------------- EXCEPTION --------------------
MSG: 
ERROR: Forked process(es) died: read-through of cross-process communication detected

STACK Bio::EnsEMBL::VEP::Runner::_forked_buffer_to_output /hps/software/users/ensembl/repositories/nuno/ensembl-vep/modules/Bio/EnsEMBL/VEP/Runner.pm:562
STACK Bio::EnsEMBL::VEP::Runner::next_output_line /hps/software/users/ensembl/repositories/nuno/ensembl-vep/modules/Bio/EnsEMBL/VEP/Runner.pm:367
STACK Bio::EnsEMBL::VEP::Runner::run /hps/software/users/ensembl/repositories/nuno/ensembl-vep/modules/Bio/EnsEMBL/VEP/Runner.pm:208
STACK toplevel /hps/software/users/ensembl/repositories/nuno/ensembl-vep/vep:46
Date (localtime)    = Fri Nov 24 15:41:25 2023
Ensembl API version = 112
---------------------------------------------------
```

When regulatory was disabled, VEP would successfully run, but then couldn't display the results, returning instead the following error message:
![screenshot_2023-11-24_at_13 47 37](https://github.com/Ensembl/VEP_plugins/assets/3199157/3079a102-faa5-4bab-bfba-42bd32441a06)

After discussing with the team, it doesn't make sense to report short variant-associated phenotypes in SVs. As such, by default, we now exclude `Variation` annotation types for SVs. Users can still force using them with `include_types=Variation` (updated the plugin description to reflect this).

## Changelog

- Avoid annotating SVs with short variant-associated phenotypes by default
- Simplify plugin argument description
- Update SYNOPSIS to quickly reflect how to use plugin
- Simplify triggering of error message when no file is found and `offline` mode is enabled

## Testing

The following SV was the problematic one:

```
13 32307062 sv1 . <DEL> . . SVTYPE=DEL;END=32908738
```

By default, VEP should now handle this case quickly in both CLI and web VEP. The issue with `--regulatory` is non-existing anymore.

The VEP command used in web VEP is similar to:
```
vep --id '13 32307062 sv1 . <DEL> . . SVTYPE=DEL;END=32908738' --fork 4 --regulatory --plugin Phenotypes,dir=$pheno,phenotype_feature=1,exclude_sources='COSMIC&HGMD-PUBLIC&Cancer_Gene_Census'
```

1. Test `include_types=Variation` to check if you still get variant-associated phenotypes in SVs like before this PR (this scenario will probably give trouble with such a big SV).
2. Test this SV in web VEP: http://wp-np2-11.ebi.ac.uk:6070/Tools/VEP
    - Enable 'Phenotypes'
    - Test with regulatory on and off