### PR TITLE
Annotate SV in UTRAnnotator

### DIFF
--- a/UTRAnnotator.pm
+++ b/UTRAnnotator.pm
@@ -43,7 +43,7 @@ limitations under the License.
                     from https://github.com/Ensembl/UTRannotator
                   - Download from http://sorfs.org
     max_overlap : (Optional) Maximum percentage of overlap between variant and
-                  UTR to avoid UTR annotation (default: 100)
+                  UTR for UTR annotation (default: 100)
 
     Citation
 

--- a/UTRAnnotator.pm
+++ b/UTRAnnotator.pm
@@ -32,8 +32,7 @@ limitations under the License.
 
 =head1 DESCRIPTION
  
-    A VEP plugin that annotates the effect of 5' UTR variant especially for
-    variant creating/disrupting upstream ORFs.
+    A VEP plugin that annotates the effect of 5' UTR variant especially for variant creating/disrupting upstream ORFs.
     Available for both GRCh37 and GRCh38.
 
     Options are passed to the plugin as key=value pairs:

--- a/UTRAnnotator.pm
+++ b/UTRAnnotator.pm
@@ -36,7 +36,7 @@ limitations under the License.
     variant creating/disrupting upstream ORFs.
     Available for both GRCh37 and GRCh38.
 
-    Options are passed to the plugin as key=value pairs, (defaults in parentheses):
+    Options are passed to the plugin as key=value pairs:
 
     file        : (Required) Path to UTRAnnotator data file:
                   - Download 'uORF_5UTR_GRCh37_PUBLIC.txt' or 'uORF_5UTR_GRCh38_PUBLIC.txt'
@@ -1322,3 +1322,4 @@ sub find_uorf_evidence {
 }
 
 1;
+                          

--- a/UTRAnnotator.pm
+++ b/UTRAnnotator.pm
@@ -123,11 +123,11 @@ sub new {
 sub get_header_info {
 
   my $self->{_header_info} = {
-        "5UTR_consequence" => "'Variant consequence from UTRAnnotator'",
-        "5UTR_annotation" => "'Variant annotation from UTRAnnotator'",
-        Existing_uORFs => "'The number of existing uORFs with a stop codon within the 5 prime UTR'",
-        Existing_OutOfFrame_oORFs => "'The number of existing out-of-frame overlapping ORFs (OutOfFrame oORF) at the 5 prime UTR'",
-        Existing_InFrame_oORFs => "'The number of existing inFrame overlapping ORFs (inFrame oORF) at the 5 prime UTR'",
+        '5UTR_consequence' => 'Variant consequence from UTRAnnotator',
+        '5UTR_annotation' => 'Variant annotation from UTRAnnotator',
+        Existing_uORFs => 'The number of existing uORFs with a stop codon within the 5 prime UTR',
+        Existing_OutOfFrame_oORFs => 'The number of existing out-of-frame overlapping ORFs (OutOfFrame oORF) at the 5 prime UTR',
+        Existing_InFrame_oORFs => 'The number of existing inFrame overlapping ORFs (inFrame oORF) at the 5 prime UTR',
   };
   return $self->{_header_info};
 }
@@ -140,8 +140,8 @@ sub run {
 
   #retrieve the variant info
   my $vf = $tva->can('variation_feature') ? $tva->variation_feature : $tva->structural_variation_feature;
-  my $chr = ($vf->{chr}   || $vf->seq_region_name);
-  my $pos = ($vf->{start} || $vf->seq_region_start);
+  my $chr     = ($vf->{chr}   || $vf->seq_region_name);
+  my $pos     = ($vf->{start} || $vf->seq_region_start);
   my $pos_end = ($vf->{end}   || $vf->seq_region_end);
   my @alleles = split /\//, $vf->allele_string;
   my $ref = shift @alleles;
@@ -188,6 +188,7 @@ sub run {
     push(@five_utr_starts, $UTR_start);
     push(@five_utr_ends,   $UTR_end);
   }
+  return {} unless (@five_utr_starts || @five_utr_ends);
 
   my @sorted_starts = sort {$a <=> $b} @five_utr_starts;
   my @sorted_ends = sort {$a <=> $b} @five_utr_ends;
@@ -285,8 +286,8 @@ sub run {
     $consequence = join(",", @consequences);
 
     %utr_effect = (
-        "5UTR_consequence" => defined($output_five_prime_flag)? $output_five_prime_flag: "-",
-        "5UTR_annotation" => defined($consequence)? $consequence: "-",
+        "5UTR_consequence" => defined($output_five_prime_flag) ? $output_five_prime_flag : "-",
+        "5UTR_annotation" => defined($consequence) && $consequence ne '' ? $consequence : "-",
     );
 
   }
@@ -1322,4 +1323,3 @@ sub find_uorf_evidence {
 }
 
 1;
-                          


### PR DESCRIPTION
Related with ENSVAR-5486

## Changelog

- Allow to annotate SVs with UTRAnnotator
- Add new argument `max_overlap`: maximum percentage of overlap between variant and UTR for UTR annotation
- Improve file download instructions

## Testing

Some example variants to test with:

```
5  36876937 .  CC A    . . .
5  36876936 . .  <DEL> . . SVTYPE=DEL;END=36876939
18 13730626 . .  <DEL> . . SVTYPE=DEL;END=13730755
18 13730675 sv18 .  <DEL> . . SVTYPE=DEL;END=13730752
19 49453225 . .  <DEL> . . SVTYPE=DEL;END=49690898
19 49453225 . .  <DEL> . . SVTYPE=DEL;END=49695898
```

Test with different `max_overlap` values.