### PR TITLE
Fix MaveDB checks for RegulatoryFeature and MotifFeature

### DIFF
--- a/MaveDB.pm
+++ b/MaveDB.pm
@@ -188,7 +188,11 @@ sub _aminoacid_changes_match {
   $aa_alt = $aa_ref if $aa_alt eq "="; # silent mutation
   $aa_alt = "Ter"   if $aa_alt eq "*"; # nonsense mutation
 
-  my $vf_aa_ref = $tva->base_variation_feature_overlap->get_reference_TranscriptVariationAllele->peptide;
+  # return no match if cannot fetch reference allele
+  my $bvf = $tva->base_variation_feature_overlap;
+  return 0 unless $bvf->can('get_reference_TranscriptVariationAllele');
+
+  my $vf_aa_ref = $bvf->get_reference_TranscriptVariationAllele->peptide;
   my $vf_aa_alt = $tva->peptide;
   my $vf_aa_pos = $tva->base_variation_feature_overlap->translation_start;
   return 0 unless defined $vf_aa_ref && defined $vf_aa_alt && defined $vf_aa_pos;
@@ -205,6 +209,9 @@ sub _aminoacid_changes_match {
 
 sub _transcripts_match {
   my ($self, $tva, $transcript) = @_;
+
+  # return no match if cannot fetch transcript from TVA
+  return 0 unless $tva->can('transcript');
 
   # Get transcript ID for Ensembl and RefSeq
   my $tr = $tva->transcript;


### PR DESCRIPTION
Fixes #665

MaveDB is returning warnings when some MaveDB variants fall inside regulatory regions.

If the MaveDB variant has a transcript and/or protein associated, `RegulatoryFeature` and `MotifFeature` now simply return `0` when trying to check for its transcript/protein.

## Testing

Test VEP using the MaveDB plugin with `--regulatory` enabled on the following set of variants: [test_github.zip](https://github.com/Ensembl/VEP_plugins/files/13828822/test_github.zip)

```
vep -i test_github.vcf \
    --database \
    --regulatory \
    --plugin MaveDB,file=MaveDB_variants.tsv.gz
```