### PR TITLE
Fix del / ins error. Add MAX option

### DIFF
--- a/Conservation.pm
+++ b/Conservation.pm
@@ -33,6 +33,7 @@ limitations under the License.
  ./vep -i variations.vcf --plugin Conservation,/path/to/bigwigfile.bw
  ./vep -i variations.vcf --plugin Conservation,/path/to/bigwigfile.bw,MAX
  ./vep -i variations.vcf --plugin Conservation,database,GERP_CONSERVATION_SCORE,mammals
+ ./vep -i variations.vcf --plugin Conservation,database,GERP_CONSERVATION_SCORE,mammals,MAX
 
 =head1 DESCRIPTION
 
@@ -65,6 +66,7 @@ use Bio::EnsEMBL::Slice;
 use Bio::EnsEMBL::IO::Parser::BigWig;
 use Bio::EnsEMBL::Variation::Utils::BaseVepPlugin;
 use Net::FTP;
+use Data::Dumper;
 
 use base qw(Bio::EnsEMBL::Variation::Utils::BaseVepPlugin);
 
@@ -210,8 +212,14 @@ sub run {
   }
   # Grab the score
   my @values = ();
-  push @values, $parser->{waiting_block}[3];
-  my $divide = 1;
+  my $length = $parser->{waiting_block}[2] - $parser->{waiting_block}[1];
+  my $divide = 0;
+  while($length >= 2) {
+    push @values, $parser->{waiting_block}[3];
+    $divide++;
+    $length--;
+  }
+#  print Dumper($parser);
   
   # If multiple bases affected, grab those scores as well from the oparser object
   foreach (@{ $parser->{cache}->{features} }) {
@@ -224,6 +232,8 @@ sub run {
         $length--;
     }
   }
+  print "@values\n";
+  print "$divide\n";
   $parser->next;
 
   # Output - if multiple scores do average or max, if single score just output that.

--- a/Conservation.pm
+++ b/Conservation.pm
@@ -137,9 +137,9 @@ sub feature_types {
 sub get_header_info {
 
     my $self = shift;
-    
+    my $method_str = $self->{method} eq 'MAX' ? "maximum" : "average";
     return {
-        Conservation => "The conservation score for this site"
+        Conservation => "The $method_str conservation score for this site"
     };
 }
 

--- a/Conservation.pm
+++ b/Conservation.pm
@@ -31,6 +31,7 @@ limitations under the License.
  
  ./vep -i variations.vcf --plugin Conservation,mammals
  ./vep -i variations.vcf --plugin Conservation,/path/to/bigwigfile.bw
+ ./vep -i variations.vcf --plugin Conservation,/path/to/bigwigfile.bw,MAX
  ./vep -i variations.vcf --plugin Conservation,database,GERP_CONSERVATION_SCORE,mammals
 
 =head1 DESCRIPTION
@@ -44,7 +45,9 @@ limitations under the License.
 
  If a variant affects multiple nucleotides the average score for the
  position will be returned, and for insertions the average score of
- the 2 flanking bases will be returned.
+ the 2 flanking bases will be returned. If the MAX parameter is
+ used, the maximum score of any of the affected bases will be reported
+ instead.
 
  The plugin uses the ensembl-compara API module (optional, see
  http://www.ensembl.org/info/docs/api/index.html) or obtains data
@@ -73,6 +76,15 @@ sub new {
     if(scalar(@{$self->params}) == 0){
       warn('No input parameters found for Conservation plugin');
       return $self;
+    }
+    # Check for MAX, otherwise default to AVERAGE
+    for(@{$self->params}) {
+        if ($_ eq 'MAX') {
+            $self->{method} = 'MAX';
+        }
+        else {
+            $self->{method} = 'AVERAGE';
+        }
     }
     
     $self->{use_database} = $self->params->[0] eq 'database';
@@ -189,35 +201,65 @@ sub run {
   my $chr = $vf->{chr};
   $chr =~ s/^chr//i;
 
-  $parser->seek($chr, $vf->{start} - 1, $vf->{end});
-  $parser->next;  
-  return $parser->get_raw_score ? { Conservation => sprintf("%.3f", $parser->get_raw_score)} : {};
+  #Check if insertion and adjust to capture flanking bases
+  if ($vf->{start} - 1 == $vf->{end}){
+    $parser->seek($chr, $vf->{start} - 2, $vf->{end} + 1);
+  }
+  else{
+    $parser->seek($chr, $vf->{start} - 1, $vf->{end});
+  }
+  # Grab the score
+  my @values = ();
+  push @values, $parser->{waiting_block}[3];
+  my $divide = 1;
+  
+  # If multiple bases affected, grab those scores as well from the oparser object
+  foreach (@{ $parser->{cache}->{features} }) {
+    my $length = @{$_}[2] - @{$_}[1];
+    # If the interval of the feature is >2 it means multiple positions have the same score
+    # Below code will capture if single or multiple scores are in the interval.
+    while($length >= 2) {
+        push @values, @{$_}[3];
+        $divide++;
+        $length--;
+    }
+  }
+  $parser->next;
+
+  # Output - if multiple scores do average or max, if single score just output that.
+  if (scalar(@values) > 1 ) {
+    if ($self->{method} eq 'MAX') {
+        my @sorted = sort(@values);
+        return { Conservation => sprintf("%.3f", $sorted[-1])};
+    }
+    else {
+        my $total = 0;
+        $total += $_ for @values;
+        my $average = $total / $divide;
+        return { Conservation => sprintf("%.3f", $average)};
+    }
+  }
+  else {
+    return { Conservation => sprintf("%.3f", $values[0])};
+  }
 }
 
 sub db_run {
     my ($self, $bvfoa) = @_;
-
     my $bvf = $bvfoa->base_variation_feature;
 
     # we cache the score on the BaseVariationFeature so we don't have to
     # fetch it multiple times if this variant overlaps multiple Features
-
     unless (exists $bvf->{_conservation_score}) {
-
         my $slice;
-
         my $true_snp = 0;
-
         if ($bvf->{end} >= $bvf->{start}) {
-
             if ($bvf->{start} == $bvf->{end}) {
 
                 # work around a bug in the compara API that means you can't fetch 
                 # conservation scores for 1bp slices by creating a 2bp slice for
                 # SNPs and then ignoring the score returned for the second position
-
                 my $s = $bvf->slice;
-
                 $slice = Bio::EnsEMBL::Slice->new(
                     -seq_region_name   => $s->seq_region_name,
                     -seq_region_length => $s->seq_region_length,
@@ -226,24 +268,18 @@ sub db_run {
                     -end               => $bvf->{end} + 1,
                     -strand            => $bvf->{strand},
                     -adaptor           => $s->adaptor
-                );
-                
+                );               
                 $true_snp = 1;
             }
             else {
-
                 # otherwise, just get a slice that covers our variant feature
-
                 $slice = $bvf->feature_Slice;
             }
         }
         else {
-
             # this is an insertion, we return the average score of the flanking 
             # bases, so we create a 2bp slice around the insertion site
-
             my $s = $bvf->slice;
-
             $slice = Bio::EnsEMBL::Slice->new(
                 -seq_region_name   => $s->seq_region_name,
                 -seq_region_length => $s->seq_region_length,
@@ -262,20 +298,25 @@ sub db_run {
         );
 
         if (@$scores > 0) {
-
-            # we use the simple average of the diff_scores as the overall score
-            
+            # we use the simple average of the diff_scores as the overall score         
             pop @$scores if $true_snp; # get rid of our spurious second score for SNPs
+            my @values;
             
-            if (@$scores > 0) {
+            for (@$scores) {
+                push @values, $_->diff_score;
+            }
 
-                my $tot_score = 0;
-    
-                $tot_score += $_->diff_score for @$scores;
-    
-                $tot_score /= @$scores;
-                
-                $bvf->{_conservation_score} = sprintf "%.3f", $tot_score;
+            if (@$scores > 0) {
+                if ($self->{method} eq 'AVERAGE') {
+                    my $tot_score = 0;
+                    $tot_score += $_ for @values;
+                    $tot_score /= @values;
+                    $bvf->{_conservation_score} = sprintf "%.3f", $tot_score;
+                }
+                elsif ($self->{method} eq 'MAX') {
+                    my @sorted = sort(@values);
+                    $bvf->{_conservation_score} = sprintf "%.3f", $sorted[-1];
+                }
             }
             else {
                 $bvf->{_conservation_score} = undef;
@@ -295,5 +336,4 @@ sub db_run {
         return {};
     }
 }
- 
 1;

--- a/Conservation.pm
+++ b/Conservation.pm
@@ -66,7 +66,6 @@ use Bio::EnsEMBL::Slice;
 use Bio::EnsEMBL::IO::Parser::BigWig;
 use Bio::EnsEMBL::Variation::Utils::BaseVepPlugin;
 use Net::FTP;
-use Data::Dumper;
 
 use base qw(Bio::EnsEMBL::Variation::Utils::BaseVepPlugin);
 
@@ -214,12 +213,12 @@ sub run {
   my @values = ();
   my $length = $parser->{waiting_block}[2] - $parser->{waiting_block}[1];
   my $divide = 0;
+
   while($length >= 2) {
     push @values, $parser->{waiting_block}[3];
     $divide++;
     $length--;
   }
-#  print Dumper($parser);
   
   # If multiple bases affected, grab those scores as well from the oparser object
   foreach (@{ $parser->{cache}->{features} }) {
@@ -232,8 +231,6 @@ sub run {
         $length--;
     }
   }
-  print "@values\n";
-  print "$divide\n";
   $parser->next;
 
   # Output - if multiple scores do average or max, if single score just output that.


### PR DESCRIPTION
Ticket: ENSVAR-6144

User spotted issue with Conservation plugin not assigning GERP scores correctly for insertions and deletions when using the file option. More details in the ticket.