### PR TITLE
Improve and optimise GWAS plugin

### DIFF
--- a/GWAS.pm
+++ b/GWAS.pm
@@ -57,7 +57,7 @@ limitations under the License.
  Please keep the filename format as it is because filename is parsed to get information.
  
  When run for the first time for either type of file, the plugin will create a processed file that have genomic locations and indexed and 
- put it under the --dir location determined by Ensembl VEP. If use_db=1 option is used, depending on the file size it might take hour(s) to create 
+ put it under the --dir location determined by Ensembl VEP. If db=1 option is used, depending on the file size it might take hour(s) to create 
  the processed file. Subsequent runs will be faster as the plugin will be using the already generated processed file. This option is not used by 
  default and the variant information is generally taken directly from the file provided.
 
@@ -66,7 +66,8 @@ limitations under the License.
  file     : (mandatory) Path to GWAS curated or summary statistics file
  type     : type of the file. Valid values are "curated" and "sstate" (summary statistics). Default is "curated".
  verbose  : display info level messages. Valid values are 0 or 1. Default is 0.
- use_db   : get variant information from Ensembl database during creation of processed file. Valid values are 0 or 1. Default is 0.
+ db       : get variant information from Ensembl database during creation of processed file. Valid values are 0 or 1. If Default is 0 (variant
+            information is retrieved from curated file)
 
 =cut
 
@@ -100,7 +101,7 @@ sub new {
     $self->{type} eq "curated" || $self->{type} eq "sstate");
 
   $self->{verbose} = $param_hash->{verbose} || 0;
-  $self->{use_db} = $param_hash->{use_db} || 0;
+  $self->{db} = $param_hash->{db} || 0;
   
   # processed file is assumed to be present under --dir 
   my $config = $self->{config};
@@ -175,7 +176,7 @@ sub run {
   my @data =  @{$self->get_data($vf->{chr}, $vf->{start} - 2, $vf->{end})};
   
   foreach (@data) {
-    # if use_db=0 is used we do not check ref allele 
+    # if db=0 is used we do not check ref allele 
     $_->{ref} = $vf->ref_allele_string if ($_->{ref} eq "" || $_->{ref} eq "N");
 
     my $matches = get_matched_variant_alleles(
@@ -344,7 +345,7 @@ sub parse_curated_file {
 
     my $t_data = dclone \%data;
     
-    my $vfs = $self->{use_db} ? $self->get_vfs_from_db($id) : $self->get_vfs_from_file($chr, $start, $end);
+    my $vfs = $self->{db} ? $self->get_vfs_from_db($id) : $self->get_vfs_from_file($chr, $start, $end);
     $t_data->{"id"} = $id;
     $t_data->{"vfs"} = $vfs;
     

--- a/GWAS.pm
+++ b/GWAS.pm
@@ -90,7 +90,7 @@ sub new {
   
   $self->expand_left(0);
   $self->expand_right(0);
-  
+
   my $param_hash = $self->params_to_hash();
 
   die "ERROR: please supply a file of NHGRI-EBI GWAS Catalog data using the 'file' parameter to use the GWAS plugin\n" unless defined $param_hash->{file};
@@ -201,25 +201,15 @@ sub run {
 sub get_vfs_from_db {
   my ($self, $id) = @_;
 
-  my $reg = 'Bio::EnsEMBL::Registry';
-  my $config = $self->{config};
+  if (!defined $self->{va}) {
+    my $reg = $self->{config}->{reg};
+    my $config = $self->{config};
 
-  if($config->{host}) {
-      $reg->load_registry_from_db(
-          -host       => $config->{host},
-          -user       => $config->{user},
-          -pass       => $config->{password},
-          -port       => $config->{port},
-          -species    => $config->{species},
-          -db_version => $config->{db_version},
-          -no_cache   => $config->{no_slice_cache},
-      );
+    $self->{va} = $reg->get_adaptor($config->{species}, 'variation', 'variation');
   }
-
-  my $va = $reg->get_adaptor($config->{species}, 'variation', 'variation');
-  return [] unless defined $va;
+  return [] unless defined $self->{va};
   
-  my $v = $va->fetch_by_name($id);
+  my $v = $self->{va}->fetch_by_name($id);
   return [] unless defined $v;
   
   my $locations = [];

--- a/GWAS.pm
+++ b/GWAS.pm
@@ -56,7 +56,7 @@ limitations under the License.
  
  Please keep the filename format as it is because filename is parsed to get information.
  
- When run for the first time the for either type of file plugin will create a processed file that have genomic locations and indexed and 
+ When run for the first time for either type of file, the plugin will create a processed file that have genomic locations and indexed and 
  put it under the --dir location determined by Ensembl VEP. If use_db=1 option is used, depending on the file size it might take hour(s) to create 
  the processed file. Subsequent runs will be faster as the plugin will be using the already generated processed file. This option is not used by 
  default and the variant information is generally taken directly from the file provided.

--- a/GWAS.pm
+++ b/GWAS.pm
@@ -66,7 +66,7 @@ limitations under the License.
  file     : (mandatory) Path to GWAS curated or summary statistics file
  type     : type of the file. Valid values are "curated" and "sstate" (summary statistics). Default is "curated".
  verbose  : display info level messages. Valid values are 0 or 1. Default is 0.
- db       : get variant information from Ensembl database during creation of processed file. Valid values are 0 or 1. If Default is 0 (variant
+ db       : get variant information from Ensembl database during creation of processed file. Valid values are 0 or 1. Default is 0 (variant
             information is retrieved from curated file)
 
 =cut

--- a/GWAS.pm
+++ b/GWAS.pm
@@ -64,7 +64,7 @@ limitations under the License.
  Options are passed to the plugin as key=value pairs:
 
  file     : (mandatory) Path to GWAS curated or summary statistics file
- type     : type of the file. Valid values are "curated" and "sstate". Default is "curated".
+ type     : type of the file. Valid values are "curated" and "sstate" (summary statistics). Default is "curated".
  verbose  : display info level messages. Valid values are 0 or 1. Default is 0.
  use_db   : get variant information from Ensembl database during creation of processed file. Valid values are 0 or 1. Default is 0.
 

--- a/GWAS.pm
+++ b/GWAS.pm
@@ -174,7 +174,9 @@ sub run {
   my @data =  @{$self->get_data($vf->{chr}, $vf->{start} - 2, $vf->{end})};
   
   foreach (@data) {
-    $_->{ref} = $vf->ref_allele_string if $_->{ref} eq "";
+    # if use_db=0 is used we do not check ref allele 
+    $_->{ref} = $vf->ref_allele_string if ($_->{ref} eq "" || $_->{ref} eq "N");
+    
     my $matches = get_matched_variant_alleles(
       {
         ref    => $vf->ref_allele_string,
@@ -236,9 +238,9 @@ sub get_vfs_from_db {
 sub get_vfs_from_file {
   my ($self, $chr, $start, $end) = @_;
 
-  my @chrs = split(/[;,x]/, $chr);
-  my @starts = split(/[;,x]/, $start);
-  my @ends = split(/[;,x]/, $end);
+  my @chrs = map { local $_ = $_; s/\s+//g; $_ } split(/[;,x]/, $chr);
+  my @starts = map { local $_ = $_; s/\s+//g; $_ } split(/[;,x]/, $start);
+  my @ends = map { local $_ = $_; s/\s+//g; $_ } split(/[;,x]/, $end);
 
   my $locations = [];
   for (0..$#chrs) {

--- a/GWAS.pm
+++ b/GWAS.pm
@@ -65,7 +65,7 @@ limitations under the License.
 
  file     : (mandatory) Path to GWAS curated or summary statistics file
  type     : type of the file. Valid values are "curated" and "sstate". Default is "curated".
- quiet    : do not display warning messages. Valid values are 0 or 1. Default is 0.
+ verbose  : display info level messages. Valid values are 0 or 1. Default is 0.
  use_db   : get variant information from Ensembl database during creation of processed file. Valid values are 0 or 1. Default is 0.
 
 =cut
@@ -99,7 +99,7 @@ sub new {
   die "ERROR: provided type ($self->{type}) is not recognized\n" unless(
     $self->{type} eq "curated" || $self->{type} eq "sstate");
 
-  $self->{quiet} = $param_hash->{quiet} || 0;
+  $self->{verbose} = $param_hash->{verbose} || 0;
   $self->{use_db} = $param_hash->{use_db} || 0;
   
   # processed file is assumed to be present under --dir 
@@ -277,7 +277,7 @@ sub parse_curated_file {
   my $start          = $content->{'CHR_POS'};;
   my $end            = $content->{'CHR_POS'};; 
 
-  warn "WARNING: 'DISEASE/TRAIT' entry is empty for '$rs_id'\n" if (($phenotype eq '') && !$self->{quiet});
+  warn "INFO: 'DISEASE/TRAIT' entry is empty for '$rs_id'\n" if (($phenotype eq '') && $self->{verbose});
   return {} if ($phenotype eq '');
 
   $gene =~ s/\s+//g;
@@ -335,7 +335,7 @@ sub parse_curated_file {
   }
 
   # if we did not get any rsIds, skip this row (this will also get rid of the header)
-  warn "WARNING: Could not parse any rsIds from string '$rs_id'\n" if (!scalar(@ids) && !$self->{quiet});
+  warn "INFO: Could not parse any rsIds from string '$rs_id'\n" if (!scalar(@ids) && $self->{verbose});
   return {} if (!scalar(@ids));
 
   my @phenotypes;

--- a/GWAS.pm
+++ b/GWAS.pm
@@ -64,6 +64,7 @@ limitations under the License.
 
  file   : (mandatory) Path to GWAS curated or summary statistics file
  type   : type of the file. Valid values are "curated" and "sstate".
+ quiet  : do not display warning messages
 
 =cut
 
@@ -95,6 +96,8 @@ sub new {
   $self->{type} = $param_hash->{type} || "curated";
   die "ERROR: provided type ($self->{type}) is not recognized\n" unless(
     $self->{type} eq "curated" || $self->{type} eq "sstate");
+
+  $self->{quiet} = $param_hash->{quiet} || 0;
   
   # processed file is assumed to be present under --dir 
   my $config = $self->{config};
@@ -245,7 +248,7 @@ sub parse_curated_file {
   my $ratio_info     = $content{'95% CI (TEXT)'};
   my @accessions     = split/\,/, $content{'MAPPED_TRAIT_URI'};
 
-  warn "WARNING: 'DISEASE/TRAIT' entry is empty for '$rs_id'\n" if ($phenotype eq '');
+  warn "WARNING: 'DISEASE/TRAIT' entry is empty for '$rs_id'\n" if (($phenotype eq '') && !$self->{quiet});
   next if ($phenotype eq '');
 
   $gene =~ s/\s+//g;
@@ -303,7 +306,7 @@ sub parse_curated_file {
   }
 
   # if we did not get any rsIds, skip this row (this will also get rid of the header)
-  warn "WARNING: Could not parse any rsIds from string '$rs_id'\n" if (!scalar(@ids));
+  warn "WARNING: Could not parse any rsIds from string '$rs_id'\n" if (!scalar(@ids) && !$self->{quiet});
   next if (!scalar(@ids));
 
   map {


### PR DESCRIPTION
https://github.com/Ensembl/VEP_plugins/issues/684

- Added new option `quiet`. If `quiet=1` is given warnings are suppressed.
- Improved memory usage. Before the full curated file data was loaded into memory. Now we load only one line into memory at a time and print it into the "to be" processed file. This [curated file](https://www.ebi.ac.uk/gwas/api/search/downloads/alternative) took max ~200MB memory in the server.
- Improved run time for creating processed file. By default, we were querying Ensembl database to get variant information. This is more accurate but we also have this information in the given GWAS file. This [curated file](https://www.ebi.ac.uk/gwas/api/search/downloads/alternative) with >500k lines took 1.5 min in the server. Introduced new option `use_db` and when `use_db=1` is used plugin reverts back to using database.


### Test
example input - 
```
7	95125673	.	G	A	.	.
7	95125673	.	G	T	.	.
6	28005587	.	C	A	.	.	
11	117110070	.	G	C	.	.
1	204190659	.	G	A	.	.
1	204190659	.	G	C	.	.
```

curated file download link - https://www.ebi.ac.uk/gwas/api/search/downloads/alternative