### PR TITLE
GeneSplicer: improve argument processing

### DIFF
--- a/GeneSplicer.pm
+++ b/GeneSplicer.pm
@@ -29,6 +29,7 @@ limitations under the License.
 
  mv GeneSplicer.pm ~/.vep/Plugins
  ./vep -i variants.vcf --plugin GeneSplicer,[path_to_genesplicer_bin],[path_to_training_dir],[option1=value],[option2=value]
+ ./vep -i variants.vcf --plugin GeneSplicer,$GS/bin/linux/genesplicer,$GS/human,context=200,tmpdir=/mytmp
 
 =head1 DESCRIPTION
 
@@ -41,48 +42,52 @@ limitations under the License.
  sequence included either side defaults to 100bp, but can be modified
  by passing e.g. "context=50" as a parameter to the plugin.
 
- Any predicted splicing regions that overlap the variant are reported
- in the output with one of four states: no_change, diff, gain, loss
+ You will need to download the GeneSplicer binary and data from
+ ftp://ftp.ccb.jhu.edu/pub/software/genesplicer/GeneSplicer.tar.gz. Extract the
+ folder using:
 
- There follows a "/"-separated string consisting of the following data:
+ tar -xzf GeneSplicer.tar.gz
 
- 1) type (donor, acceptor)
- 2) coordinates (start-end)
- 3) confidence (Low, Medium, High)
- 4) score
+ GeneSplicer comes with precompiled binaries for multiple systems. If the
+ provided binaries do not run, compile `genesplicer` from source:
 
- Example: loss/acceptor/727006-727007/High/16.231924
+ ```
+ cd $GS/sources
+ # if macOS, run this step
+ [[ $(uname -s) == "Darwin" ]] && perl -pi -e "s/^main  /int main  /" genesplicer.cpp
+ make
+ cd -
+ ./vep [options] --plugin GeneSplicer,$GS/sources/genesplicer,$GS/human
+ ```
+
+ Predicted splicing regions that overlap the variant are reported in the output
+ with a '/'-separated string (e.g., 'loss/acceptor/727006-727007/High/16.231924')
+ consisting of the following data by this order:
+
+ 1) state (no_change, diff, gain, loss)
+ 2) type (donor, acceptor)
+ 3) coordinates (start-end)
+ 4) confidence (Low, Medium, High)
+ 5) score
 
  If multiple sites are predicted, their reports are separated by ",".
 
  For diff, the confidence and score for both the reference and alternate
- sequences is reported as REF-ALT.
-
- Example: diff/donor/621915-621914/Medium-Medium/7.020731-6.988368
+ sequences is reported as REF-ALT, such as
+ 'diff/donor/621915-621914/Medium-Medium/7.020731-6.988368'.
 
  Several key=value parameters can be modified in the the plugin string:
 
+ binary     : path to `genesplicer` binary (default: `genesplicer`)
+ training   : directory to species training data (such as, `GeneSplicer/human`)
  context    : change the amount of sequence added either side of
               the variant (default: 100bp)
- tmpdir     : change the temporary directory used (default: /tmp)
+ tmpdir     : change the temporary directory used (default: `/tmp`)
  cache_size : change how many sequences' scores are cached in memory
               (default: 50)
 
  Example:
    --plugin GeneSplicer,$GS/bin/linux/genesplicer,$GS/human,context=200,tmpdir=/mytmp
-
- On some systems the binaries provided will not execute, but can be compiled from source:
-
-   cd $GS/sources
-   make
-   cd -
-   ./vep [options] --plugin GeneSplicer,$GS/sources/genesplicer,$GS/human
-
- On Mac OSX the make step is known to fail; the genesplicer.cpp file requires modification:
-
-   cd $GS/sources
-   perl -pi -e "s/^main  /int main  /" genesplicer.cpp
-   make
  
 
 =cut
@@ -115,14 +120,12 @@ sub _check_binary {
   my $test = `$bin 2>&1` || '';
   die("ERROR: failed to run genesplicer binary:\n$test\n") unless $test =~ /^USAGE/;
    = $bin;
-  return 1;
 }
 
 sub _check_training_dir {
   my $training_dir = shift;
   die("ERROR: training directory not specified\n") unless $training_dir;
   die("ERROR: training directory not found\n") unless -d $training_dir;
-  return 1;
 }
 
 sub new {

--- a/GeneSplicer.pm
+++ b/GeneSplicer.pm
@@ -118,8 +118,11 @@ sub new {
 
   my $bin = shift @$params;
   die("ERROR: genesplicer binary not specified\n") unless $bin;
+  # if $bin is the genesplicer command, try to get its path to check if it exists
+  $bin = (`which $bin 2>&1` || '') unless -e bin;
   die("ERROR: genesplicer binary not found\n") unless -e $bin;
-  my $test = `$bin 2>&1`;
+
+  my $test = `$bin 2>&1` || '';
   die("ERROR: failed to run genesplicer binary:\n$test\n") unless $test =~ /^USAGE/;
   $self->{_bin} = $bin;
   

--- a/GeneSplicer.pm
+++ b/GeneSplicer.pm
@@ -121,14 +121,13 @@ our %DEFAULTS = (
 );
 
 sub _check_binary {
-  my $bin = shift;
-  # if $bin is the genesplicer command, try to get its path to check if it exists
-  $bin = (`which $bin 2>&1` || '') unless -e bin;
-  die("ERROR: genesplicer binary not found\n") unless -e $bin;
+  my $binary_file = shift;
+  # if $binary_file is the genesplicer command, try to get its path to check if it exists
+  $binary_file = (`which $binary_file 2>&1` || '') unless -e $binary_file;
+  die("ERROR: genesplicer binary not found\n") unless -e $binary_file;
 
-  my $test = `$bin 2>&1` || '';
+  my $test = `$binary_file 2>&1` || '';
   die("ERROR: failed to run genesplicer binary:\n$test\n") unless $test =~ /^USAGE/;
-   = $bin;
 }
 
 sub _check_training_dir {

--- a/GeneSplicer.pm
+++ b/GeneSplicer.pm
@@ -165,8 +165,9 @@ sub new {
     }
   }
 
-  $self->{_bin} if _check_binary($self->{_bin});
-  $self->{_training_dir} if _check_training_dir($self->{_training_dir});
+  $self->{_bin} ||= 'genesplicer';
+  _check_binary($self->{_bin});
+  _check_training_dir($self->{_training_dir});
   return $self;
 }
 

--- a/GeneSplicer.pm
+++ b/GeneSplicer.pm
@@ -78,8 +78,9 @@ limitations under the License.
 
  Several key=value parameters can be modified in the the plugin string:
 
+ training   : (mandatory) directory to species-specific training data, such as
+              `GeneSplicer/human`
  binary     : path to `genesplicer` binary (default: `genesplicer`)
- training   : directory to species training data (such as, `GeneSplicer/human`)
  context    : change the amount of sequence added either side of
               the variant (default: 100bp)
  tmpdir     : change the temporary directory used (default: `/tmp`)

--- a/GeneSplicer.pm
+++ b/GeneSplicer.pm
@@ -28,8 +28,12 @@ limitations under the License.
 =head1 SYNOPSIS
 
  mv GeneSplicer.pm ~/.vep/Plugins
- ./vep -i variants.vcf --plugin GeneSplicer,[path_to_genesplicer_bin],[path_to_training_dir],[option1=value],[option2=value]
- ./vep -i variants.vcf --plugin GeneSplicer,$GS/bin/linux/genesplicer,$GS/human,context=200,tmpdir=/mytmp
+ ./vep -i variants.vcf --plugin GeneSplicer,binary=$GS/bin/linux/genesplicer,training=$GS/human
+ ./vep -i variants.vcf --plugin GeneSplicer,binary=$GS/bin/linux/genesplicer,training=$GS/human,context=200,tmpdir=/mytmp
+
+ # VEP Docker/Singularity: if 'genesplicer' is a command available in $PATH,
+ # there is no need to specify the location of the binary
+ ./vep -i variants.vcf --plugin GeneSplicer,training=$GS/human
 
 =head1 DESCRIPTION
 
@@ -88,8 +92,12 @@ limitations under the License.
               (default: 50)
 
  Example:
-   --plugin GeneSplicer,$GS/bin/linux/genesplicer,$GS/human,context=200,tmpdir=/mytmp
- 
+   --plugin GeneSplicer,binary=$GS/bin/linux/genesplicer,training=$GS/human,context=200,tmpdir=/mytmp
+
+ When using VEP Docker/Singularity, the `binary` argument can be ommitted, as
+ the `genesplicer` command is exported in the $PATH variable and is thus
+ automatically detected by the plugin:
+   --plugin GeneSplicer,training=$GS/human,context=200,tmpdir=/mytmp
 
 =cut
 

--- a/GeneSplicer.pm
+++ b/GeneSplicer.pm
@@ -124,6 +124,7 @@ sub _check_binary {
   my $binary_file = shift;
   # if $binary_file is the genesplicer command, try to get its path to check if it exists
   $binary_file = (`which $binary_file 2>&1` || '') unless -e $binary_file;
+  chomp $binary_file;
   die("ERROR: genesplicer binary not found\n") unless -e $binary_file;
 
   my $test = `$binary_file 2>&1` || '';


### PR DESCRIPTION
Improves on https://github.com/Ensembl/ensembl-vep/pull/1599

## Changelog
- Accept `genesplicer` command instead of a path
    - Works if `genesplicer` is exported in the `$PATH` variable (like in VEP Docker)
    - Path to `genesplicer` is internally obtained via `which`
- Add key-value params to first two positional arguments:
    - `binary` with `genesplicer` as default
    - `training` with no default
- Improve plugin docs
    - Add information on how to use GeneSplicer with VEP Docker/Singularity

## Testing

If `genesplicer` is exported in the `$PATH` variable, like in VEP Docker/Singularity (https://github.com/Ensembl/ensembl-vep/pull/1599), there is no need to explicitly call it:

```
vep --id rs1348242192 --database --force --plugin GeneSplicer,training=${human_data}
```

This means that the only mandatory argument now is the training data.