### PR TITLE
PolyPhen_SIFT plugin: add meta table to sqlite3 database

### DIFF
--- a/PolyPhen_SIFT.pm
+++ b/PolyPhen_SIFT.pm
@@ -28,7 +28,17 @@ limitations under the License.
 =head1 SYNOPSIS
 
  mv PolyPhen_SIFT.pm ~/.vep/Plugins
+
+ # Read PolyPhen/SIFT data from default SQLite database in $HOME/.vep
  ./vep -i variations.vcf -cache --plugin PolyPhen_SIFT
+
+ # Read database with custom name and/or located in a custom directory
+ ./vep -i variations.vcf -cache --plugin PolyPhen_SIFT,db=custom.db
+ ./vep -i variations.vcf -cache --plugin PolyPhen_SIFT,dir=/some/custom/dir
+ ./vep -i variations.vcf -cache --plugin PolyPhen_SIFT,db=custom.db,dir=/some/custom/dir
+
+ # Create database by copying Ensembl data locally
+ ./vep -i variations.vcf -cache --plugin PolyPhen_SIFT,create_db=1
 
 =head1 DESCRIPTION
 
@@ -40,25 +50,25 @@ limitations under the License.
  You must create a SQLite database of the predictions or point to the SQLite
  database file already created.
 
- You may point to the file by adding db=[file] as a parameter:
+ You may point to the file by adding parameter `db=[file]`:
 
  --plugin PolyPhen_SIFT,db=[file]
 
- Place the SQLite database file in $HOME/.vep to have the plugin find it automatically.
- You may change this directory by adding dir=[dir] as a parameter:
+ Place the SQLite database file in `HOME/.vep` so that the plugin finds it
+ automatically. You may change this directory by adding parameter `dir=[dir]`:
 
  --plugin PolyPhen_SIFT,dir=[dir]
 
- To create the database, you must have an active database connection
- (i.e. not using --offline) and add create_db=1 as a parameter:
+ To create a SQLite database using PolyPhen/SIFT data from the Ensembl database,
+ you must have an active database connection (i.e. not using `--offline`) and
+ add parameter `create_db=1`. This will create a SQLite file named
+ `[species].PolyPhen_SIFT.db`, placed in the directory specified by the `dir`
+ parameter:
 
  --plugin PolyPhen_SIFT,create_db=1
+ --plugin PolyPhen_SIFT,create_db=1,dir=/some/specific/directory
 
- *** NB: this will take some time!!! ***
-
- By default the file is created as:
-
- ${HOME}/.vep/[species].PolyPhen_SIFT.db
+ *** NB: this will take some hours! ***
  
 =cut
 

--- a/PolyPhen_SIFT.pm
+++ b/PolyPhen_SIFT.pm
@@ -29,7 +29,7 @@ limitations under the License.
 
  mv PolyPhen_SIFT.pm ~/.vep/Plugins
 
- # Read PolyPhen/SIFT data from default SQLite database in $HOME/.vep
+ # Read default PolyPhen/SIFT SQLite file in $HOME/.vep
  ./vep -i variations.vcf -cache --plugin PolyPhen_SIFT
 
  # Read database with custom name and/or located in a custom directory
@@ -48,16 +48,14 @@ limitations under the License.
  does not contain these predictions.
 
  You must create a SQLite database of the predictions or point to the SQLite
- database file already created.
+ database file already created. Compatible SQLite databases based on pangenome
+ data are available at http://ftp.ensembl.org/pub/current_variation/pangenomes
 
- You may point to the file by adding parameter `db=[file]`:
+ You may point to the file by adding parameter `db=[file]`. If the file is not
+ in `HOME/.vep`, you can also use parameter `dir=[dir]` to indicate its path.
 
  --plugin PolyPhen_SIFT,db=[file]
-
- Place the SQLite database file in `HOME/.vep` so that the plugin finds it
- automatically. You may change this directory by adding parameter `dir=[dir]`:
-
- --plugin PolyPhen_SIFT,dir=[dir]
+ --plugin PolyPhen_SIFT,db=[file],dir=[dir]
 
  To create a SQLite database using PolyPhen/SIFT data from the Ensembl database,
  you must have an active database connection (i.e. not using `--offline`) and
@@ -69,7 +67,12 @@ limitations under the License.
  --plugin PolyPhen_SIFT,create_db=1,dir=/some/specific/directory
 
  *** NB: this will take some hours! ***
- 
+
+ When creating a PolyPhen_SIFT by simply using `create_db=1`, you do not need to
+ specify any parameters to load the appropriate file based on the species:
+
+ --plugin PolyPhen_SIFT
+
 =cut
 
 package PolyPhen_SIFT;

--- a/PolyPhen_SIFT.pm
+++ b/PolyPhen_SIFT.pm
@@ -37,7 +37,7 @@ limitations under the License.
  ./vep -i variations.vcf -cache --plugin PolyPhen_SIFT,dir=/some/custom/dir
  ./vep -i variations.vcf -cache --plugin PolyPhen_SIFT,db=custom.db,dir=/some/custom/dir
 
- # Create database by copying Ensembl data locally
+ # Create PolyPhen/SIFT SQLite file based on Ensembl database
  ./vep -i variations.vcf -cache --plugin PolyPhen_SIFT,create_db=1
 
 =head1 DESCRIPTION

--- a/plugin_config.txt
+++ b/plugin_config.txt
@@ -874,6 +874,15 @@ my $VEP_PLUGIN_CONFIG = {
       ]
     },
 
+    # PolyPhen_SIFT
+    {
+      "key" => "PolyPhen_SIFT",
+      "available" => 0,
+      "enabled" => 0,
+      "section" => "Pathogenicity predictions",
+      "plugin_url" => "https://raw.githubusercontent.com/Ensembl/VEP_plugins/release/112/PolyPhen_SIFT.pm",
+    },
+
     ## SPLICING PREDICTIONS
     #######################
 
@@ -1810,14 +1819,6 @@ my $VEP_PLUGIN_CONFIG = {
       "available" => 0,
       "enabled" => 0,
       "plugin_url" => "https://raw.githubusercontent.com/Ensembl/VEP_plugins/release/112/CSN.pm",
-    },
-
-    # PolyPhen_SIFT
-    {
-      "key" => "PolyPhen_SIFT",
-      "available" => 0,
-      "enabled" => 0,
-      "plugin_url" => "https://raw.githubusercontent.com/Ensembl/VEP_plugins/release/112/PolyPhen_SIFT.pm",
     },
   ]
 };

--- a/plugin_config.txt
+++ b/plugin_config.txt
@@ -1811,5 +1811,13 @@ my $VEP_PLUGIN_CONFIG = {
       "enabled" => 0,
       "plugin_url" => "https://raw.githubusercontent.com/Ensembl/VEP_plugins/release/112/CSN.pm",
     },
+
+    # PolyPhen_SIFT
+    {
+      "key" => "PolyPhen_SIFT",
+      "available" => 0,
+      "enabled" => 0,
+      "plugin_url" => "https://raw.githubusercontent.com/Ensembl/VEP_plugins/release/112/PolyPhen_SIFT.pm",
+    },
   ]
 };


### PR DESCRIPTION
ENSVAR-4600

* [**Create meta table in sqlite3 database**](https://github.com/Ensembl/VEP_plugins/commit/54a94cb17f9d0160e7850303c4e0e9a251dc1ea3)
* **Add SIFT/PPH2 plugin to public docs:** we are going to recommend users to use it when working with pangenome assemblies

## Testing

1. Using a human MySQL database with a small number of protein function predictions (the full pangenomes database takes ~12h to produce the output), run VEP with PolyPhen_SIFT plugin with `create_db=1` and check if the `meta` table was copied to the sqlite database:
    ```bash
    sqlite3 human_pangenomes.PolyPhen_SIFT.db 'select * from meta'
    ```
2. Check documentation update in [my sandbox](http://wp-np2-11.ebi.ac.uk:6070/info/docs/tools/vep/script/vep_plugins.html)