### PR TITLE
mutfunc: Skip annotation if no sequence

### DIFF
--- a/mutfunc.pm
+++ b/mutfunc.pm
@@ -91,10 +91,8 @@ sub new {
 
   my $param_hash = $self->params_to_hash();
 
-  $self->{annotate} = 1;
   if ($self->{config}->{offline} && !$self->{config}->{fasta}) {
-    warn "The mutfunc plugin cannot annotate without translation sequence, please provide a FASTA if --offline is used\n";
-    $self->{annotate} = 0;  
+    die "The mutfunc plugin cannot annotate without translation sequence, please provide a FASTA if --offline is used\n";
   }
 
   # default behavior is to output all field
@@ -388,8 +386,6 @@ sub run {
   my ($self, $tva) = @_;
 
   my $result = {};
-
-  return $result unless $self->{annotate};
 
   my $hash_from_db = $self->process_from_db($tva);
   @$result{ keys %$hash_from_db } = values %$hash_from_db;

--- a/mutfunc.pm
+++ b/mutfunc.pm
@@ -43,8 +43,9 @@ limitations under the License.
  1) The data file. mutfunc SQLite db can be downloaded from - 
  https://ftp.ensembl.org/pub/current_variation/mutfunc/mutfunc_data.db
 
- By default all the fields (motif, int, mod, and exp) are added in the output. But if you want to have some selected fields and not all of
- them just select the relevant options. The default behavior will then go away outputting only the selected fields.
+ 2) If you are using --offline please provide a FASTA file as this plugin requires the
+ translation sequence to function.
+
  Options are passed to the plugin as key=value pairs:
 
  db			  : (mandatory) Path to SQLite database containing data for other analysis.
@@ -53,6 +54,9 @@ limitations under the License.
  mod      : Select this option to have mutfunc protein structure analysis in the output
  exp      : Select this option to have mutfunc protein structure (experimental) analysis in the output
  extended : By default mutfunc outputs the most significant field for any analysis. Select this option to get more verbose output.
+
+ By default all of the four type of analysis (motif, int, mod, and exp) data are available in the output. But if you want to have 
+ some selected analysis and not all of them just select the relevant options.
 
 =cut
 

--- a/mutfunc.pm
+++ b/mutfunc.pm
@@ -87,6 +87,12 @@ sub new {
 
   my $param_hash = $self->params_to_hash();
 
+  $self->{annotate} = 1;
+  if ($self->{config}->{offline} && !$self->{config}->{fasta}) {
+    warn "The mutfunc plugin cannot annotate without translation sequence, please provide a FASTA if --offline is used\n";
+    $self->{annotate} = 0;  
+  }
+
   # default behavior is to output all field
   $param_hash->{all} = 1 if (
     (!defined $param_hash->{motif}) &&
@@ -378,6 +384,8 @@ sub run {
   my ($self, $tva) = @_;
 
   my $result = {};
+
+  return $result unless $self->{annotate};
 
   my $hash_from_db = $self->process_from_db($tva);
   @$result{ keys %$hash_from_db } = values %$hash_from_db;


### PR DESCRIPTION
The mutfunc plugin needs translation sequence for annotation. The VEP cache do not have the translation sequence. So, when `--offline` is used without a FASTA mutfunc do not annotate anything. Added a warning and skip any annotation logic altogether for such case.

### Test
```
vep -i <repo_dir>/ensembl-vep/examples/homo_sapiens_GRCh38.vcf --cache <cache_dir> --cache_version 112 -a GRCh38 --force --plugin mutfunc,db=<plugin data_dir>/mutfunc_data.db --offline
```