### PR TITLE
Conservation: fix when there is no conservation data

### DIFF
--- a/Conservation.pm
+++ b/Conservation.pm
@@ -209,6 +209,9 @@ sub run {
   else{
     $parser->seek($chr, $vf->{start} - 1, $vf->{end});
   }
+  
+  return {} unless $parser->{waiting_block};
+
   # Grab the score
   my @values = ();
   my $length = $parser->{waiting_block}[2] - $parser->{waiting_block}[1];


### PR DESCRIPTION
issue reported: https://github.com/Ensembl/VEP_plugins/issues/731

We should check for undef values in the parser.

### Test
```
vep --id "1 977935 . G A" --cache /path/to/tabixconverted --fasta /path/to/Homo_sapiens.GRCh38.dna.toplevel.fa.gz --force --cache_version 112 -a GRCh38 --offline --plugin Conservation,/path/to/gerp_conservation_scores.homo_sapiens.GRCh38.bw
```