### PR TITLE
Changed logic for calculating new peptide length

### DIFF
--- a/Downstream.pm
+++ b/Downstream.pm
@@ -121,6 +121,12 @@ sub run {
       -alphabet => 'dna'
     );
 
+    my $codon_seq_full = Bio::Seq->new(
+      -seq      => $cds_seq,
+      -moltype  => 'dna',
+      -alphabet => 'dna'
+    );
+
     my $codon_table;
     if(defined($tr->{_variation_effect_feature_cache})) {
         $codon_table = $tr->{_variation_effect_feature_cache}->{codon_table} || 1;
@@ -131,19 +137,15 @@ sub run {
     }
 
     my $new_pep = $codon_seq->translate(undef, undef, undef, $codon_table)->seq();
-    $new_pep =~ s/\*.*//;
+    my $pep_with_var = $codon_seq_full->translate(undef, undef, undef, $codon_table)->seq();
 
     my $translation = defined($tr->{_variation_effect_feature_cache}->{peptide})
                     ? $tr->{_variation_effect_feature_cache}->{peptide}
                     : $tr->translation->seq;
 
-    my ($pep_start, $pep_end) = ($tv->translation_start, $tv->translation_end);
-
-    my $new_length = ($pep_start < $pep_end ? $pep_start : $pep_end) + length($new_pep);
-
     return {
         DownstreamProtein   => $new_pep,
-        ProteinLengthChange => $new_length - length($translation),
+        ProteinLengthChange => length($pep_with_var) - length($translation),
     };
 }
 

--- a/Downstream.pm
+++ b/Downstream.pm
@@ -122,7 +122,7 @@ sub run {
     );
 
     my $codon_seq_full = Bio::Seq->new(
-      -seq      => $cds_seq,
+      -seq      => substr($cds_seq,0,$last_complete_codon).$codon_seq->seq,
       -moltype  => 'dna',
       -alphabet => 'dna'
     );

--- a/Downstream.pm
+++ b/Downstream.pm
@@ -137,12 +137,12 @@ sub run {
     }
 
     my $new_pep = $codon_seq->translate(undef, undef, undef, $codon_table)->seq();
+    $new_pep =~ s/\*.*//;
     my $pep_with_var = $codon_seq_full->translate(undef, undef, undef, $codon_table)->seq();
-
+    $pep_with_var =~ s/\*.*//;
     my $translation = defined($tr->{_variation_effect_feature_cache}->{peptide})
                     ? $tr->{_variation_effect_feature_cache}->{peptide}
                     : $tr->translation->seq;
-
     return {
         DownstreamProtein   => $new_pep,
         ProteinLengthChange => length($pep_with_var) - length($translation),


### PR DESCRIPTION
Ticket: [ENSVAR-6621](https://www.ebi.ac.uk/panda/jira/browse/ENSVAR-6621)

## Testing
```
vep -i input.vcf \
-o Result.vcf \
--assembly GRCh38 --no_stats --fork 4 --force \
--cache --offline --db_version 112 --use_given_ref \
--dir_cache <cache_dir> \
--fasta <fasta_file> \
--dir_plugins <plugins_dir> \
--vcf  \
--sift s --polyphen s --total_length --numbers \
--hgvs --protein --symbol --ccds --tsl --canonical  --mane --biotype \
--check_existing --exclude_null_alleles \
--cache_version 112 \
--plugin Downstream 
```

## Input
```
chr1    2430625 .   C   CGTGGGTGAGTGAGGCCCTGGCT
```

To check if there is no breaking change for other variants