### PR TITLE
Allow gnomAD v4 data for LOEUF plugin

### DIFF
--- a/LOEUF.pm
+++ b/LOEUF.pm
@@ -86,15 +86,13 @@ use Scalar::Util qw(looks_like_number);
 # gnomAD v2 and v4 data have different headers
 my $valid_headers = {
   "v2" => {
-    1 => "transcript",
-    30 => "oe_lof_upper",
-    64 => "gene_id"
+    "index" => [1, 30, 64],
+    "header" => ["transcript", "oe_lof_upper", "gene_id"]
   },
   "v4" => {
-    2 => "transcript",
-    22 => "lof.oe_ci.upper",
-    1 => "gene_id"
-  },
+    "index" => [2, 22, 1],
+    "header" => ["transcript", "lof.oe_ci.upper", "gene_id"]
+  }
 };
 
 sub new {
@@ -129,12 +127,14 @@ sub new {
 
   my @missing_columns;
   foreach my $version (keys %{ $valid_headers }){
+    my $i = 0;
     @missing_columns = ();
-    foreach my $index (keys %{ $valid_headers->{$version} }){
-      my $exp_column = $valid_headers->{$version}->{$index};
+    foreach my $index ( @{ $valid_headers->{$version}->{"index"} }){
+      my $exp_column = $valid_headers->{$version}->{"header"}->[$i];
       my $obs_column = $headers->[$index] ? $headers->[$index] : "";
 
       push @missing_columns, $exp_column if $exp_column ne $obs_column;
+      $i++;
     }
 
     unless (@missing_columns) {
@@ -218,7 +218,7 @@ sub parse_data {
   my @values = split /\t/, $line;
 
   my ($transcript_id, $oe_lof_upper, $gene_id) = $self->{data_version} ? 
-    @values[keys %{ $valid_headers->{$self->{data_version}} }] : @values[1,30,64];
+    @values[ @{ $valid_headers->{$self->{data_version}}->{"index"} } ] : @values[1,30,64];
   return {
     gene_id => $gene_id,
     transcript_id => $transcript_id,

--- a/pLI.pm
+++ b/pLI.pm
@@ -68,6 +68,9 @@ pLI - Add pLI score to the VEP output
     ./vep -i variants.vcf --plugin pLI,values_file.txt
     ./vep -i variants.vcf --plugin pLI,values_file.txt,transcript # to check for the transcript score.
 
+  gnomAD v4 release expanded the scale of pLI score calculation. The file can be downloaded from -
+    https://gnomad.broadinstitute.org/downloads#v4-constraint (Constraint metrics TSV)
+  To use the data you can follow the same procedure as above but needs to change the column number to accordingly.
 
 =cut
 


### PR DESCRIPTION
https://www.ebi.ac.uk/panda/jira/browse/ENSVAR-6429

gnomAD have published LOEUF data for GRCh38 in v4 release. The headers are different than what we had in v2. This PR allows both of them to be able to use with the plugin.

For pLI, only added a comment to say it is possible to use v4 data. The preparation step is similar, so we do not want to add another ~5M file in the repo.

### Test
Check the JIRA ticket