### PR TITLE
Fix SpliceAI alleles match

### DIFF
--- a/SpliceAI.pm
+++ b/SpliceAI.pm
@@ -208,13 +208,14 @@ sub run {
     # Convert VF ins/del to VCF to be able to compare alleles
     if($vf->allele_string =~ /-/) {
         my $convert_to_vcf = $vf->to_VCF_record;
+        $start = ${$convert_to_vcf}[1];
         $ref_allele = ${$convert_to_vcf}[3];
         my $alt_allele_string = ${$convert_to_vcf}[4];
         my @aux_alt = split /,/, $alt_allele_string;
         $alt_allele = $aux_alt[$allele_number - 1];
     }
 
-    if ($ref_allele eq $data_value->{ref} && $alt_allele eq $data_value->{alt}) {
+    if ($start == $data_value->{start} && $ref_allele eq $data_value->{ref} && $alt_allele eq $data_value->{alt}) {
       my %hash;
 
       if($output_vcf || $self->{config}->{output_format} eq "json" || $self->{config}->{rest})  {


### PR DESCRIPTION
For input:
`chr2 1542420 . GGA G . . .`

The plugin finds two matches:
2 1542420 . GGA G . . SpliceAI=G|TPO|0.92|0.89|0.00|0.00|3|1|-30|1 -> correct
2 1542421 . GAG G . . SpliceAI=G|TPO|0.00|0.00|0.00|0.00|0|3|-31|-45 -> incorrect

This PR changes the way the plugin matches the alleles.

Ticket: [ENSVAR-6407](https://www.ebi.ac.uk/panda/jira/browse/ENSVAR-6407)