### PR TITLE
Fix phenotypes plugin - remove intergenic from feature_types

### DIFF
--- a/Phenotypes.pm
+++ b/Phenotypes.pm
@@ -206,7 +206,7 @@ sub new {
 }
 
 sub feature_types {
-  return ['Feature','Intergenic'];
+  return ['Feature'];
 }
 
 sub variant_feature_types {


### PR DESCRIPTION
The plugin reports overlapping phenotype features to the input features - it fetches the transcript and gene from the variation_feature. It doesn't make sense to include intergenic in this case.

This is a possible fix for this issue https://github.com/Ensembl/VEP_plugins/issues/753