### PR TITLE
Fixed missing data file in the LOEUF Plugin documentation.

### DIFF
--- a/CADD.pm
+++ b/CADD.pm
@@ -99,8 +99,6 @@ my %INCLUDE_COLUMNS = (
 
 my $NON_COMMERCIAL_USE_CLAUSE = "CADD is only available here for non-commercial use. See CADD website for more information.";
 
-  my $ALT_NUM = 0;
-
 sub new {
   my $class = shift;
   
@@ -210,18 +208,10 @@ sub run {
   if ($bvf->isa("Bio::EnsEMBL::Variation::VariationFeature")){
     $start = $bvf->{start};
     $end = $bvf->{end};
-    $allele = $bvf->alt_alleles->[$ALT_NUM];
+    $allele = $tva->variation_feature_seq;
     $ref = $bvf->ref_allele_string;
 
-
-    if (($ALT_NUM + 1) >= scalar(@{$bvf->alt_alleles})) {
-      $ALT_NUM = 0;
-    } else {
-      $ALT_NUM += 1;
-    };
-
     return {} unless defined($allele) && $allele =~ /^[ACGT-]+$/;
-    $ALT_NUM = 0; # setting $ALT_NUM = 0 
 
   } else {
     # Do not annotate sv if there is snv/indels annotation file

--- a/LOEUF.pm
+++ b/LOEUF.pm
@@ -48,7 +48,7 @@ limitations under the License.
 
 
  LOEUF scores can be downloaded from
- https://www.ncbi.nlm.nih.gov/pmc/articles/PMC7334197/bin/41586_2020_2308_MOESM4_ESM.zip
+ https://static-content.springer.com/esm/art%3A10.1038%2Fs41586-020-2308-7/MediaObjects/41586_2020_2308_MOESM4_ESM.zip
 
  For GRCh37:
  These files can be tabix-processed by:


### PR DESCRIPTION
Minor fix. The URL  pointing to the supplementary material in pubmed is giving a 404. I replaced it with the URL for the supplementary materials in the publisher's site.