### PR TITLE
feat: allowing downstream distances from TSS

### DIFF
--- a/TSSDistance.pm
+++ b/TSSDistance.pm
@@ -55,9 +55,8 @@ sub new {
     # Get directionality flag:
     my $param_hash = $self->params_to_hash();
 
-    # If both_direction is set to 1, we will calculate the distance from the TSS in both directions, otherwise only upstream distance will be calculated:
-    $self->{both_direction} = (defined($param_hash->{both_direction}) && $param_hash->{both_direction} == 1 ? 1 : 0);
-
+    # If both_direction parameter is set, we will calculate the distance from the TSS in both directions, otherwise only upstream distance will be calculated:
+    $self->{both_direction} = defined($param_hash->{both_direction}) ? 1 : 0;
     return $self;
 }
 
@@ -96,18 +95,16 @@ sub run {
             TSSDistance => $dist,
         }
     }
+
     # Downstream distance only returned if both_direction flag is set to 1:
-    elsif ($self->{both_direction} == 1){
+    if ($self->{both_direction} == 1){
         return {
             TSSDistance => $dist,
         }
     }
+
     # Otherwise return empty hash:
-    else{
-
-        return {};
-
-    }
+    return {};
 }
 
 1;

--- a/TSSDistance.pm
+++ b/TSSDistance.pm
@@ -55,8 +55,8 @@ sub new {
     # Get directionality flag:
     my $param_hash = $self->params_to_hash();
 
-    # If both_direction parameter is set, we will calculate the distance from the TSS in both directions, otherwise only upstream distance will be calculated:
-    $self->{both_direction} = defined($param_hash->{both_direction}) ? 1 : 0;
+    # If both_direction parameter is set, distance is reported for both upstream and downstream variants, otherwise distance for only upstream variants will be reported:
+    $self->{both_direction} = $param_hash->{both_direction} ? 1 : 0;
     return $self;
 }
 

--- a/TSSDistance.pm
+++ b/TSSDistance.pm
@@ -37,7 +37,7 @@ limitations under the License.
 
  A VEP plugin that calculates the distance from the transcription
  start site for upstream variants. Or variants in both directions
- if parameter downstream is set to 1.
+ if parameter `both_direction=1` is provided.
 
 =cut
 


### PR DESCRIPTION
## Context

The default behaviour of the `TSSDistance` plugin is to annotate variants with 3' distance to transcripts. However often it is also of interest to know how far a variant is even if it is downstream to the transcription start site. This PR enrich this plugin with a feature to enable returning downstream distances as well if requested via a plugin parameter. This PR addresses issue #768 

**!Important to note**: the default behaviour of the plugin is unchanged. User has to provide extra parameter to invoke new feature. 