### PR TITLE
Update NearestExonJB

### DIFF
--- a/NearestExonJB.pm
+++ b/NearestExonJB.pm
@@ -43,6 +43,7 @@ limitations under the License.
  Various key=value parameters can be altered by passing them to the plugin command:
 
    max_range : maximum search range in bp (default: 10000)
+   intronic  : set to 1 to check nearest exon for intronic variants (default: 0)
 
  Parameters are passed e.g.:
 
@@ -63,6 +64,7 @@ my $char_sep = "|";
 
 my %CONFIG = (
   max_range => 10000,
+  intronic => 0
 );
 
 sub new {
@@ -109,6 +111,11 @@ sub run {
     my $exons = $trv->_overlapped_exons;
     my %dists;
     my $min = $CONFIG{max_range};
+
+    if(scalar @{$exons} == 0 && $CONFIG{intronic} == 1) {
+      $exons = $trv->_sorted_exons;
+    }
+
     foreach my $exon (@$exons) {
       my $startD = abs ($vf->start - $exon->seq_region_start);
       my $endD = abs ($vf->end - $exon->seq_region_end);

--- a/NearestExonJB.pm
+++ b/NearestExonJB.pm
@@ -34,7 +34,7 @@ limitations under the License.
 
  This is a plugin for the Ensembl Variant Effect Predictor (VEP) that
  finds the nearest exon junction boundary to a coding sequence variant. More than 
- one boundary may be reported if the boundaries are equidistant or if run option
+ one boundary may be reported if the boundaries are equidistant or if using option
  --intronic.
 
  The plugin will report the Ensembl identifier of the exon, the distance to the
@@ -46,7 +46,8 @@ limitations under the License.
    max_range : maximum search range in bp (default: 10000)
 
    intronic  : set to 1 to check nearest exons for intronic variants (default: 0)
-               returns the nearest exon upstream and downstream
+               returns the nearest exon upstream and downstream without considering
+               the max_range.
 
 
  Parameters are passed e.g.:

--- a/NearestExonJB.pm
+++ b/NearestExonJB.pm
@@ -168,7 +168,6 @@ sub run {
 
     my @finalRes;
     # For option --intronic, return the closest exons (upstream/dowsntream) from the intron
-    # Format example: ENSE00003511683|len:143|8899:start,ENSE00003541627|1764:end|len:69
     if(scalar @{$exons} == 2 && $CONFIG{intronic} == 1) {
       foreach my $exon (keys %dists) {
         my $inner_hash = $dists{$exon};

--- a/NearestExonJB.pm
+++ b/NearestExonJB.pm
@@ -117,10 +117,13 @@ sub run {
     my $min = $CONFIG{max_range};
 
     if(scalar @{$exons} == 0 && $CONFIG{intronic} == 1) {
-      $exons = $trv->_sorted_exons;
       my $intron_numbers = $trv->intron_number();
+      my $consequences = join(",", map { $_->SO_term } @{$tva->get_all_OverlapConsequences});
 
-      if(defined $intron_numbers) {
+      # print "Consequences: $consequences\n";
+
+      if(defined $intron_numbers && $consequences =~ /intron/) {
+        $exons = $trv->_sorted_exons;
         my ($intron_number, $total_number) = split(/\//, $intron_numbers);
         # print "Intron number: $intron_number\n";
 
@@ -143,7 +146,6 @@ sub run {
         $exons = \@exons_tmp;
         # print "-> ", scalar(@{$exons}), "\n";
       }
-
     }
 
     foreach my $exon (@$exons) {

--- a/NearestExonJB.pm
+++ b/NearestExonJB.pm
@@ -34,7 +34,8 @@ limitations under the License.
 
  This is a plugin for the Ensembl Variant Effect Predictor (VEP) that
  finds the nearest exon junction boundary to a coding sequence variant. More than 
- one boundary may be reported if the boundaries are equidistant.
+ one boundary may be reported if the boundaries are equidistant or if run option
+ --intronic.
 
  The plugin will report the Ensembl identifier of the exon, the distance to the
  exon boundary, the boundary type (start or end of exon) and the total
@@ -43,11 +44,16 @@ limitations under the License.
  Various key=value parameters can be altered by passing them to the plugin command:
 
    max_range : maximum search range in bp (default: 10000)
-   intronic  : set to 1 to check nearest exon for intronic variants (default: 0)
+
+   intronic  : set to 1 to check nearest exons for intronic variants (default: 0)
+               returns the nearest exon upstream and downstream
+
 
  Parameters are passed e.g.:
 
    --plugin NearestExonJB,max_range=50000
+   --plugin NearestExonJB,max_range=50000,intronic=1
+   --plugin NearestExonJB,intronic=1
 
 =cut
 

--- a/NearestExonJB.pm
+++ b/NearestExonJB.pm
@@ -98,7 +98,15 @@ sub feature_types {
 }
 
 sub get_header_info {
-  my $header = 'Nearest Exon Junction Boundary (coding sequence variants only). Format:';
+  my $header;
+
+  if($CONFIG{intronic} == 1) {
+    $header = 'Nearest Exon Junction Boundary. Format:';
+  }
+  else {
+    $header = 'Nearest Exon Junction Boundary (coding sequence variants only). Format:';
+  }
+
   $header .= join($char_sep, qw(ExonID distance start/end length) );
 
   return {
@@ -134,7 +142,7 @@ sub run {
         my $exon_after = $intron_number + 1;
 
         my @exons_tmp;
-        # Reverse strand we get the exons from the end of the list
+        # In the reverse strand we get the last two exons from the list
         if($tva->transcript->strand < 0) {
           push(@exons_tmp, $exons->[-$exon_before]);
           push(@exons_tmp, $exons->[-$exon_after]);

--- a/NearestExonJB.pm
+++ b/NearestExonJB.pm
@@ -58,6 +58,8 @@ use warnings;
 
 use Bio::EnsEMBL::Variation::Utils::BaseVepPlugin;
 
+# use Data::Dumper;
+
 use base qw(Bio::EnsEMBL::Variation::Utils::BaseVepPlugin);
 
 my $char_sep = "|";
@@ -107,6 +109,8 @@ sub run {
 
   my $loc_string = sprintf("%s:%s-%i-%i", $trv->transcript_stable_id, $vf->{chr} || $vf->seq_region_name, $vf->{start}, $vf->{end});
 
+  # print "\nlocation: $loc_string\n";
+
   if(!exists($self->{_cache}) || !exists($self->{_cache}->{$loc_string})) {
     my $exons = $trv->_overlapped_exons;
     my %dists;
@@ -114,9 +118,36 @@ sub run {
 
     if(scalar @{$exons} == 0 && $CONFIG{intronic} == 1) {
       $exons = $trv->_sorted_exons;
+      my $intron_numbers = $trv->intron_number();
+
+      if(defined $intron_numbers) {
+        my ($intron_number, $total_number) = split(/\//, $intron_numbers);
+        # print "Intron number: $intron_number\n";
+
+        # Get the number of exons before and after the intron
+        my $exon_before = $intron_number;
+        my $exon_after = $intron_number + 1;
+        # print "Exon before: $exon_before, exon after: $exon_after\n";
+
+        my @exons_tmp;
+        # Reverse strand we get the exons from the end of the list
+        if($tva->transcript->strand < 0) {
+          push(@exons_tmp, $exons->[-$exon_before]);
+          push(@exons_tmp, $exons->[-$exon_after]);
+        }
+        else {
+          push(@exons_tmp, $exons->[$exon_before -1]);
+          push(@exons_tmp, $exons->[$exon_after -1]);
+        }
+
+        $exons = \@exons_tmp;
+        # print "-> ", scalar(@{$exons}), "\n";
+      }
+
     }
 
     foreach my $exon (@$exons) {
+      # print "Exon: ", $exon->stable_id, " ", $exon->start, "-", $exon->end, "\n";
       my $startD = abs ($vf->start - $exon->seq_region_start);
       my $endD = abs ($vf->end - $exon->seq_region_end);
       if ($startD < $endD){
@@ -134,10 +165,23 @@ sub run {
       }
     }
 
+    # print "--- ", Dumper(\%dists);
+
     my @finalRes;
-    foreach my $exon (keys %dists){
-      if (exists $dists{$exon}{$min}) {
-        push(@finalRes, $exon.$char_sep.$min.$char_sep.$dists{$exon}{$min}.$char_sep.$dists{$exon}{len})
+    if(scalar @{$exons} == 2 && $CONFIG{intronic} == 1) {
+      # ENSE00003492822|2056|end|75
+      foreach my $exon (keys %dists) {
+        my $inner_hash = $dists{$exon};
+        my $inner_string = join($char_sep, map { "$_:$inner_hash->{$_}" } keys %$inner_hash);
+        my $string = $exon . $char_sep . $inner_string;
+        push(@finalRes, $string);
+      }
+    }
+    else {
+        foreach my $exon (keys %dists){
+        if (exists $dists{$exon}{$min}) {
+          push(@finalRes, $exon.$char_sep.$min.$char_sep.$dists{$exon}{$min}.$char_sep.$dists{$exon}{len})
+        }
       }
     }
 
@@ -147,4 +191,3 @@ sub run {
 }
 
 1;
-


### PR DESCRIPTION
The plugin only returns overlaping exons.
This PR introduces a new option `--intronic` to report the closest exons (upstream and downstream) for intronic variants.

Related to request: https://github.com/Ensembl/ensembl-vep/issues/1834