### PR TITLE
Add MechPredict plugin

### DIFF
--- a/MechPredict.pm
+++ b/MechPredict.pm
@@ -133,7 +133,7 @@ sub read_tsv {
         # Remove trailing \n chars
         chomp;
 
-        # There are 4 cols in the .tsv file, so assign result of split to 4 usefully named variables
+# There are 4 cols in the .tsv file, so assign result of split to 4 usefully named variables
         my ( $gene, $uniprot_id, $pDN, $pGOF, $pLOF ) = split( "\t", $_ );
 
         # Store data in single hash ref per gene
@@ -186,11 +186,7 @@ sub run {
     my $transcript = $tva->transcript;
 
     # Get gene name
-    # Usually, ->get_Gene->external_name would be used, but this doesn't work in offline mode, so pull from cached value if --offline
-    # _gene_symbol is a cached value in offline mode
     my $gene_name = $transcript->{_gene_symbol};
-
-    # Return empty hash if gene name is undefined
     return {} unless $gene_name;
 
     # Check if the variant has a missense consequence
@@ -199,23 +195,29 @@ sub run {
       unless grep { $_->SO_term eq 'missense_variant' }
       @{ $tva->get_all_OverlapConsequences };
 
-    # Check whether the gene_name can be found in the MechPredict prediction data
+   # Check whether the gene_name can be found in the MechPredict prediction data
     my $gene_data = $self->{data}{$gene_name};
     return {} unless $gene_data;
 
     # Pull out MechPredict prediction data for gene_name
     my ( $pdn, $pgof, $plof ) = @{$gene_data}{qw(pDN pGOF pLOF)};
-    
+
     # Compare values to thresholds and populate prediction
     # Create prediction field
     my $prediction = "";
 
     # Check each value against its threshold and append to prediction
-    $prediction .= "gene_predicted_as_associated_with_dominant_negative_mechanism, " if $pdn  >= $thresholds{pdn};
-    $prediction .= "gene_predicted_as_associated_with_gain_of_function_mechanism, " if $pgof >= $thresholds{pgof};
-    $prediction .= "gene_predicted_as_associated_with_loss_of_function_mechanism, " if $plof >= $thresholds{plof};
+    $prediction .=
+      "gene_predicted_as_associated_with_dominant_negative_mechanism, "
+      if $pdn >= $thresholds{pdn};
+    $prediction .=
+      "gene_predicted_as_associated_with_gain_of_function_mechanism, "
+      if $pgof >= $thresholds{pgof};
+    $prediction .=
+      "gene_predicted_as_associated_with_loss_of_function_mechanism, "
+      if $plof >= $thresholds{plof};
 
-    # Remove trailing comma and space if
+    # Remove trailing comma and space
     $prediction =~ s/, $//;
 
     # If no predictions met the threshold, assign a default message


### PR DESCRIPTION
JIRA ticket: [ENSVAR-6662](https://www.ebi.ac.uk/panda/jira/browse/ENSVAR-6662) 

## Description  

This PR adds the MechPredict plugin, which annotates missense variants with one of predicted gene-level mechanisms:
- Dominant-negative (DN)
- Gain-of-function (GOF)
- Loss-of-function (LOF)

MechPredict does this by reading in gene-level probabilities predicted by an external model and assigning the most likely mechanism based on empircally-derived cut-offs described in the related manuscript. For example, if gene A has the following probability values: DN = 0.2, GOF = 0.3, LOF = 0.9, then the returned interpretation would be "gene_predicted_as_associated_with_loss_of_function_mechanism". 

## Notes

- New VEP fields added by plugin
	- `MechPredict_pDN`: Numeric  
	- `MechPredict_pGOF`: Numeric  
	- `MechPredict_pLOF`: Numeric  
	- `MechPredict_interpretation`: Character  
- The plugin only annotates transcript-variant pairs with missense_variant as the consequence. This is because the methods used by the authors to generate the predictions was optimised to assess missense mutations, the most common protein-altering mutations.  
- The plugin reads in `MechPredict_input.tsv` which can be generated using instructions in the module's header.  
- There is a known exception found during testing: 
	- The 'test with 50 missense variants - should annotate all' test will annotate 49 variants only. I believe this is to do with VEP's most severe consequence functionality - if a variant-transcript pair has >1 consequence, VEP will assign the more severe one. 
	- As such, in the case below, start_lost is assigned over missense, and so missense is removed as a consequence and is thus not annotated by MechPredict.

## Testing

### Test with 50 missense variants - should annotate all

```bash
# run vep with MechPredict
./vep --input_file /hps/software/users/ensembl/variation/fairbrot/data/test-data/clinvar_20210102_missense_50.vcf.gz \
--output_file /hps/software/users/ensembl/variation/fairbrot/MechPredict/MechPredict_test_missense_out.vcf \
--format vcf \
--vcf \
--dir_plugins /hps/software/users/ensembl/variation/fairbrot/VEP_plugins \
--plugin MechPredict,file=/nfs/production/flicek/ensembl/variation/data/MechPredict/MechPredict_input.tsv \
--offline \
--cache \
--cache_version 113 \
--dir_cache /nfs/production/flicek/ensembl/variation/data/VEP/tabixconverted \
--assembly GRCh38 \
--fasta /nfs/production/flicek/ensembl/variation/data/Homo_sapiens.GRCh38.dna.toplevel.fa.gz

# check output - are the MechPredict fields included?
cat /hps/software/users/ensembl/variation/fairbrot/MechPredict/MechPredict_test_missense_out.vcf | \
    grep -v "^#" | \
    grep "_mechanism" | 
    wc -l
```

### Test with 50 intron variants - should annotate none

```bash
# run vep with MechPredict
./vep --input_file /hps/software/users/ensembl/variation/fairbrot/data/test-data/clinvar_20210102_intron_50.vcf.gz \
--output_file /hps/software/users/ensembl/variation/fairbrot/MechPredict/MechPredict_test_intron_out.vcf \
--format vcf \
--vcf \
--dir_plugins /hps/software/users/ensembl/variation/fairbrot/VEP_plugins \
--plugin MechPredict,file=/nfs/production/flicek/ensembl/variation/data/MechPredict/MechPredict_input.tsv \
--offline \
--cache \
--cache_version 113 \
--dir_cache /nfs/production/flicek/ensembl/variation/data/VEP/tabixconverted \
--assembly GRCh38 \
--fasta /nfs/production/flicek/ensembl/variation/data/Homo_sapiens.GRCh38.dna.toplevel.fa.gz

# check output - are the MechPredict fields included?
cat /hps/software/users/ensembl/variation/fairbrot/MechPredict/MechPredict_test_intron_out.vcf | \
    grep -v "^#" | \
    grep "_mechanism" | 
    wc -l
```
