### PR TITLE
Re-introduce intergenic feature to Phenotypes plugin

### DIFF
--- a/Phenotypes.pm
+++ b/Phenotypes.pm
@@ -206,7 +206,7 @@ sub new {
 }
 
 sub feature_types {
-  return ['Feature'];
+  return ['Feature','Intergenic'];
 }
 
 sub variant_feature_types {
@@ -325,7 +325,7 @@ sub run {
   my $vf = $bvfo->base_variation_feature;
   $self->{is_sv} = $vf->isa('Bio::EnsEMBL::Variation::StructuralVariationFeature');
 
-  my $tr = $bvfo->transcript;
+  my $tr = !$bvfo->isa('Bio::EnsEMBL::Variation::IntergenicVariationAllele') ? $bvfo->transcript : undef;
   my $gene_stable_id = defined $tr ? $tr->{_gene_stable_id} : "";
 
   # adjust coords for tabix


### PR DESCRIPTION
This PR reverts https://github.com/Ensembl/VEP_plugins/pull/755
And fixes https://github.com/Ensembl/VEP_plugins/issues/753

Ticket: [ENSVAR-6767](https://www.ebi.ac.uk/panda/jira/browse/ENSVAR-6767)

Test input:
```
13 105465961 105465961 C/T
19 1022782 1022782 A/G
X 20582587 20582587 T/TC
X 20304120 20304120 C/A
```