### PR TITLE
Modify version detection in dbNSFP.pm, adding support for 5.x+

### DIFF
--- a/dbNSFP.pm
+++ b/dbNSFP.pm
@@ -182,10 +182,13 @@ sub new {
   } elsif ($file =~ /4\.0b1/) {
     # special case: different name for location column
     $version = '4.0.1';
-  } elsif ($file =~ /4\./) {
-    $version = '4';
-  } elsif ($file =~ /3\./) {
-    $version = 3;
+  } elsif ($file =~ /([3-9]\.\d+(?:\.\d+)?[ac])/) {
+    # prioritise versions with explicit 'a' or 'c' suffix
+    $version = $1;
+  } elsif ($file =~ /([3-9]\.\d+(?:\.\d+)?)/) {
+    # fallback to general version, warn user
+    $version = $1;
+    warn "WARNING: Specific suffix 'a' or 'c' not found for version $version. Proceeding with general version.\n";
   } else {
     die "ERROR: Could not retrieve dbNSFP version from filename $file\n";
   }


### PR DESCRIPTION
Hello,

**Description:**

This edit modifies version detection in dbNSFP.pm to ensure compatibility with [dbNSFP v5.x+](https://www.dbnsfp.org) and future versions. The current implementation does not detect v5.0a and will not work with similar future releases.

**Changes:**
- Generalised regex to capture versions 3.x–9.x.
- Added support for sub-versions (e.g., 5.0.1a, 5.1.2c).
- Maintained handling for special cases (2.9, 4.0b1).
- Added a warning when a specific suffix ([a]cademic/[c]ommercial) is missing but allows fallback to a general version number.

**Why this is needed:**

Without this change, dbNSFP v5.0a and similar versions are not detected which may lead to compatibility issues. This update ensures robustness for future versions while maintaining backward compatibility.

If I've messed anything up then please do let me know! 👍🏻 

All the best,

Steven.