### PR TITLE
Add option both_directions to NearestGene plugin

### DIFF
--- a/NearestGene.pm
+++ b/NearestGene.pm
@@ -41,7 +41,7 @@ limitations under the License.
 
    limit           : limit the number of genes returned (default: 1)
    range           : initial search range in bp (default: 1000)
-   max_range       : maximum search range in bp (default: 10000)
+   max_range       : maximum search range in bp (default: 50000)
    both_directions : return the nearest genes upstream and downstream of the variant
                      this option overwrites the limit to 1
                      note that the max_range affects the search range in both directions


### PR DESCRIPTION
Ticket: [ENSVAR-6770](https://embl.atlassian.net/browse/ENSVAR-6770)

New option: `both_directions`
Description: returns the nearest genes upstream and downstream of the intergenic variant
In this PR the plugin still needs a connection to the db.

Requested by https://github.com/Ensembl/ensembl-vep/issues/1834 