### PR TITLE
dbNSFP: some more non-transcript specific fields

### DIFF
--- a/dbNSFP.pm
+++ b/dbNSFP.pm
@@ -164,6 +164,11 @@ my %NON_TRANSCRIPT_SPECIFIC_FIELDS = map {$_ => 1} qw(
   Transcript_id_VEST3
   Transcript_var_VEST3
   VEST3_score
+  dbNSFP_POPMAX_AC
+  dbNSFP_POPMAX_POP
+  AllofUs_POPMAX_AC
+  AllofUs_POPMAX_AN
+  AllofUs_POPMAX_POP
 );
 
 sub new {


### PR DESCRIPTION
Hello devs,
these non-transcript-specific fields were added in dbNSFP v5.1 I believe. This patch allows to use them.
Kind regards,
Nicolas
