### PR TITLE
fix: prevent nan persisting to web vep output

### DIFF
--- a/EVE.pm
+++ b/EVE.pm
@@ -239,14 +239,15 @@ sub parse_data {
     my ($gene)      = $info =~ /(?:^|;)gene=([^;]+)/;
     my ($protein)   = $info =~ /(?:^|;)protein=([^;]+)/;
     my ($mutant)    = $info =~ /(?:^|;)mutant=([^;]+)/;
+    my $valid_number = sub { defined $_[0] && $_[0] !~ /^nan$/i };
 
     my %res;
-    $res{popEVE_SCORE}              = $score     if defined $score;
-    $res{popEVE_EVE}                = $raw_eve   if defined $raw_eve; # avoids collision with the EVE col from the EVE file
-    $res{popEVE_ESM1v}              = $esm1v     if defined $esm1v;
-    $res{popEVE_pop_adjusted_EVE}   = $padj_eve  if defined $padj_eve;
-    $res{popEVE_pop_adjusted_ESM1v} = $padj_esm  if defined $padj_esm;
-    $res{popEVE_gap_frequency}      = $gap       if defined $gap;
+    $res{popEVE_SCORE}              = $score     if $valid_number->($score);
+    $res{popEVE_EVE}                = $raw_eve   if $valid_number->($raw_eve); # avoids collision with the EVE col from the EVE file
+    $res{popEVE_ESM1v}              = $esm1v     if $valid_number->($esm1v);
+    $res{popEVE_pop_adjusted_EVE}   = $padj_eve  if $valid_number->($padj_eve);
+    $res{popEVE_pop_adjusted_ESM1v} = $padj_esm  if $valid_number->($padj_esm);
+    $res{popEVE_gap_frequency}      = $gap       if $valid_number->($gap);
     $res{popEVE_gene}               = $gene      if defined $gene;
     $res{popEVE_protein}            = $protein   if defined $protein;
     $res{popEVE_mutant}             = $mutant    if defined $mutant;

--- a/EVE.pm
+++ b/EVE.pm
@@ -239,18 +239,24 @@ sub parse_data {
     my ($gene)      = $info =~ /(?:^|;)gene=([^;]+)/;
     my ($protein)   = $info =~ /(?:^|;)protein=([^;]+)/;
     my ($mutant)    = $info =~ /(?:^|;)mutant=([^;]+)/;
-    my $valid_number = sub { defined $_[0] && $_[0] !~ /^nan$/i };
+    my %numeric_values = (
+      popEVE_SCORE              => $score,
+      popEVE_EVE                => $raw_eve, # avoids collision with the EVE col from the EVE file
+      popEVE_ESM1v              => $esm1v,
+      popEVE_pop_adjusted_EVE   => $padj_eve,
+      popEVE_pop_adjusted_ESM1v => $padj_esm,
+      popEVE_gap_frequency      => $gap,
+    );
 
-    my %res;
-    $res{popEVE_SCORE}              = $score     if $valid_number->($score);
-    $res{popEVE_EVE}                = $raw_eve   if $valid_number->($raw_eve); # avoids collision with the EVE col from the EVE file
-    $res{popEVE_ESM1v}              = $esm1v     if $valid_number->($esm1v);
-    $res{popEVE_pop_adjusted_EVE}   = $padj_eve  if $valid_number->($padj_eve);
-    $res{popEVE_pop_adjusted_ESM1v} = $padj_esm  if $valid_number->($padj_esm);
-    $res{popEVE_gap_frequency}      = $gap       if $valid_number->($gap);
-    $res{popEVE_gene}               = $gene      if defined $gene;
-    $res{popEVE_protein}            = $protein   if defined $protein;
-    $res{popEVE_mutant}             = $mutant    if defined $mutant;
+    my $missing_value = sub { !defined $_[0] || $_[0] eq '' || $_[0] eq '.' || $_[0] =~ /^nan$/i };
+
+    my %res = map { $_ => $numeric_values{$_} }
+      grep { !$missing_value->($numeric_values{$_}) }
+      keys %numeric_values;
+
+    $res{popEVE_gene}               = $gene      if !$missing_value->($gene);
+    $res{popEVE_protein}            = $protein   if !$missing_value->($protein);
+    $res{popEVE_mutant}             = $mutant    if !$missing_value->($mutant);
 
     my $end = $pos + (length($ref||'') ? length($ref)-1 : 0);
     return { ref=>$ref, alt=>$alt, start=>$pos, end=>$end, result=>\%res };


### PR DESCRIPTION
This PR updates EVE.pm so popEVE source missing values are treated as missing data, not as output values. Literal `nan` from the data file were persisting into the VEP output file/ web view. The plugin previously treated these as values and passed them through to VEP output, meaning that they appeared as `nan` instead of `-`. 

The plugin now filters missing values out of the returned hash. It treats undefined, empty string, ., and `nan` as missing. The headers remain the same so that VEP knows these cols still exist. 

What happens for each output format:  
- TSV/tab: VEP keeps the columns and renders missing values as -.
- JSON: VEP omits the missing keys  
 - VCF: VEP keeps the fields in the CSQ header and writes empty CSQ subfields.

This matches existing plugin behaviour. Plugins generally return only available annotation keys and then let missing value representation depend on the VEP formatters (i.e. tab/json/vsf) - see `dbNSFP.pm` L381, for example.

## Testing  

Download and prepare EVE and popEVE data as per `EVE.pm` header info. 

`in.vcf`:
```vcf
##fileformat=VCFv4.2
##source=vep-repro
#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO
1	230710048	rs699	A	G	.	PASS	.
```

Command: 
```bash
# tsv output
./vep \
  -i in.vcf \
  -o out.tsv \
  --dir_cache tabixconverted \
  --cache_version 116 \
  --format vcf --symbol --tab --offline --cache \
  --fasta Homo_sapiens.GRCh38.dna.toplevel.fa.gz \
  --assembly GRCh38 \
  --force_overwrite \
  --no_escape \
  --show_ref_allele \
  --no_stats \
  --plugin EVE,file=$EVE_file,class_number=50,popeve_file=$POPEVE_file 

# vcf output
./vep \
  -i in.vcf \
  -o out.vcf \
  --dir_cache tabixconverted \
  --cache_version 116 \
  --format vcf --symbol --vcf --offline --cache \
  --fasta Homo_sapiens.GRCh38.dna.toplevel.fa.gz \
  --assembly GRCh38 \
  --force_overwrite \
  --no_escape \
  --show_ref_allele \
  --no_stats \
  --plugin EVE,file=$EVE_file,class_number=50,popeve_file=$POPEVE_file 

# json output
./vep \
  -i in.vcf \
  -o out.json \
  --dir_cache tabixconverted \
  --cache_version 116 \
  --format vcf --symbol --json--offline --cache \
  --fasta Homo_sapiens.GRCh38.dna.toplevel.fa.gz \
  --assembly GRCh38 \
  --force_overwrite \
  --no_escape \
  --show_ref_allele \
  --no_stats \
  --plugin EVE,file=$EVE_file,class_number=50,popeve_file=$POPEVE_file 
```

Before this fix, running rs699 with the EVE plugin resulted in literal `nan` values for the following cols:
```
ESM1v=nan
pop-adjusted_ESM1v=nan
```