### PR TITLE
Warning for transcript match for --refseq/merged

### DIFF
--- a/AlphaMissense.pm
+++ b/AlphaMissense.pm
@@ -185,6 +185,10 @@ sub new {
   my $cols = $param_hash->{cols} || "am_pathogenicity:am_class";
   $self->_parse_colnames($cols);
 
+  if ((defined $self->{config}->{refseq} || defined $self->{config}->{merged}) && $self->{transcript_match}) {
+    warn "WARNING: AlphaMissense transcript_match may fail with --refseq/--merged; consider transcript_match=0\n";
+  }
+
   return $self;
 }
 

--- a/GO.pm
+++ b/GO.pm
@@ -149,6 +149,10 @@ sub new {
     print "### GO plugin: Retrieving GO terms from $file\n" unless $config->{quiet};
     $self->add_file($file);
     $self->get_user_params();
+
+    if ((defined $self->{config}->{refseq} || defined $self->{config}->{merged}) && $self->{match} eq 'transcript') {
+      warn "WARNING: GO transcript matching may fail with --refseq/--merged; consider using match=gene_symbol. If you had already created the GFF file, it may need to be regenerated (using match=gene_symbol).\n";
+    }
   } else {
     # Revert to old GO.pm functionality -- based on Conservation.pm
     print "### GO plugin: Retrieving GO terms from Ensembl API\n" unless $config->{quiet};

--- a/GO.pm
+++ b/GO.pm
@@ -150,7 +150,7 @@ sub new {
     $self->add_file($file);
     $self->get_user_params();
 
-    if ((defined $self->{config}->{refseq} || defined $self->{config}->{merged}) && $self->{match} eq 'transcript') {
+    if ((defined $self->{config}->{refseq} || defined $self->{config}->{merged}) && ($self->{match} eq 'transcript' || $self->{match} eq 'translation')) {
       warn "WARNING: GO transcript matching may fail with --refseq/--merged; consider using match=gene_symbol. If you had already created the GFF file, it may need to be regenerated (using match=gene_symbol).\n";
     }
   } else {

--- a/MPC.pm
+++ b/MPC.pm
@@ -46,6 +46,11 @@ limitations under the License.
 
  The data are currently mapped to GRCh37 only. Not all transcripts are included; see
  README in the above directory for exclusion criteria.
+
+ Options are passed to the plugin in order as value-only arguments:
+   file             : (mandatory) Tabix-indexed MPC data
+   transcript_match : Only print data if transcript identifiers match those from
+                      MPC data (default: 1)
  
 =cut
 
@@ -71,6 +76,13 @@ sub new {
   $self->expand_right(0);
 
   $self->get_user_params();
+
+  my $tr_match = $self->params->[1];
+  $self->{transcript_match} = defined $tr_match ? $tr_match : 1;
+
+  if ((defined $self->{config}->{refseq} || defined $self->{config}->{merged}) && $self->{transcript_match}) {
+    warn "WARNING: MPC transcript_match may fail with --refseq/--merged; consider disabling transcript_match\n";
+  }
 
   return $self;
 }
@@ -98,14 +110,11 @@ sub run {
   reverse_comp(\$allele) if $vf->{strand} < 0;
   
   return {} unless $allele =~ /^[ACGT]$/;
-  
-  # get transcript stable ID
-  my $tr_id = $tva->transcript->stable_id;
 
   my ($res) = grep {
     $_->{pos} == $vf->{start} &&
     $_->{alt} eq $allele &&
-    $_->{tr}  eq $tr_id
+    (!$self->{transcript_match} || $_->{tr} eq $tva->transcript->stable_id)
   } @{$self->get_data($vf->{chr}, $vf->{start}, $vf->{end})};
 
   return $res ? { MPC => $res->{MPC} } : {};

--- a/MTR.pm
+++ b/MTR.pm
@@ -38,6 +38,11 @@ sed '1s/.*/#&/'  mtrflatfile_2.00.tsv > mtrflatfile_2.0.tsv # to add # to the fi
 bgzip mtrflatfile_2.0.tsv
 tabix -f -s 1 -b 2 -e 2 mtrflatfile_2.0.tsv.gz
 
+Options are passed to the plugin in order as value-only arguments:
+  file             : (mandatory) Tabix-indexed MTR data
+  transcript_match : Only print data if transcript identifiers match those from
+                     MTR data (default: 1)
+
 NB: Data are available for GRCh37 only
 
 =cut
@@ -60,6 +65,9 @@ sub new {
   # get MTR file
   my $file = $self->params->[0];
   $self->add_file($file);
+
+  my $tr_match = $self->params->[1];
+  $self->{transcript_match} = defined $tr_match ? $tr_match : 1;
   
   # to check for assembly 
 
@@ -80,6 +88,10 @@ sub new {
 
   if(! grep(/^Genomic_position$/, @{$self->{headers}})) {
     die "Required header Genomic_position not found.\n";
+  }
+
+  if ((defined $self->{config}->{refseq} || defined $self->{config}->{merged}) && $self->{transcript_match}) {
+    warn "WARNING: MTR transcript_match may fail with --refseq/--merged; consider disabling transcript_match\n";
   }
 
   return $self;
@@ -112,15 +124,13 @@ sub run {
 
   return {} unless $allele =~ /^[ACGT]$/;
 
-  my $tr_id = $tva->transcript->stable_id;
-
   # data is written by pos, allele, transcript ID (feature)
   # grep lines read in matched on position so that they also are matched on allele and transcript ID
   my ($res) = grep {
     $_->{Genomic_position} == $vf->{start} &&
     $_->{Genomic_position} == $vf->{end} &&
     $_->{alt}              eq $allele &&
-    $_->{Feature}          eq $tr_id
+    (!$self->{transcript_match} || $_->{Feature} eq $tva->transcript->stable_id)
   } @{$self->get_data($vf->{chr}, $vf->{start}, $vf->{end})};
 
   # return only the keys defined by get_header_info()

--- a/PromoterAI.pm
+++ b/PromoterAI.pm
@@ -185,6 +185,10 @@ sub new {
   my $cols = $param_hash->{cols} || $default_cols;
   $self->_parse_colnames($cols);
 
+  if ((defined $self->{config}->{refseq} || defined $self->{config}->{merged}) && $self->{match_to} eq 'transcript') {
+    warn "WARNING: PromoterAI transcript matching may fail with --refseq/--merged; consider match_to=any\n";
+  }
+
   return $self;
 }
 

--- a/REVEL.pm
+++ b/REVEL.pm
@@ -141,6 +141,10 @@ sub new {
           $assembly_to_hdr{$assembly} . " in header.\n";
   }
 
+  if ((defined $self->{config}->{refseq} || defined $self->{config}->{merged}) && !$self->{no_match}) {
+    warn "WARNING: REVEL transcript matching may fail with --refseq/--merged; consider setting no_match=1\n";
+  }
+
   return $self;
 }
 

--- a/RiboseqORFs.pm
+++ b/RiboseqORFs.pm
@@ -50,6 +50,11 @@ limitations under the License.
 
  The tabix utility must be installed in your path to use this plugin.
 
+ Options are passed to the plugin as key=value pairs:
+   file             : (mandatory) Tabix-indexed Ribo-seq ORFs data
+   transcript_match : Only print data if transcript identifiers match those from
+                      Ribo-seq ORFs data (default: 1)
+
 =cut
 
 package RiboseqORFs;
@@ -83,10 +88,17 @@ sub new {
 
   # Add plugin data file
   my $param_hash = $self->params_to_hash();
+  my $tr_match = $param_hash->{transcript_match};
+  $self->{transcript_match} = defined $tr_match ? $tr_match : 1;
+
   my $file = $param_hash->{file};
   die "\n  ERROR: No file specified\nTry using 'file=path/to/Ribo-seq_ORFs.bed.gz'\n"
      unless defined($file);
   $self->add_file($file);
+
+  if ((defined $self->{config}->{refseq} || defined $self->{config}->{merged}) && $self->{transcript_match}) {
+    warn "WARNING: RiboseqORFs transcript_match may fail with --refseq/--merged; consider transcript_match=0\n";
+  }
 
   return $self;
 }
@@ -223,6 +235,7 @@ sub _recreate_TranscriptVariationAllele_with_ORF {
 
 sub run {
   my ($self, $tva) = @_;
+
   my $vf   = $tva->variation_feature;
 
   my ($vf_start, $vf_end) = ($vf->{start}, $vf->{end});
@@ -231,7 +244,9 @@ sub run {
   my @data = @{$self->get_data($vf->{chr}, $vf_start, $vf_end)};
 
   for (@data) {
-    next unless _transcripts_match($tva, $_->{'all_transcript_ids'});
+    if ($self->{transcript_match}) {
+      next unless _transcripts_match($tva, $_->{'all_transcript_ids'});
+    }
 
     my $res = _recreate_TranscriptVariationAllele_with_ORF($tva, $_);
 

--- a/SpliceVault.pm
+++ b/SpliceVault.pm
@@ -79,6 +79,11 @@ limitations under the License.
  - https://ftp.ensembl.org/pub/current_variation/SpliceVault/SpliceVault_data_hg19.tsv.gz
  - https://ftp.ensembl.org/pub/current_variation/SpliceVault/SpliceVault_data_hg19.tsv.gz.tbi
 
+   Options are passed to the plugin as key=value pairs:
+     file             : (mandatory) Tabix-indexed SpliceVault data
+     transcript_match : Only print data if transcript identifiers match those from
+                        SpliceVault data (default: 1)
+
  To filter results, please use filter_vep with the output file or standard
  output. Documentation on filter_vep is available at:
  https://www.ensembl.org/info/docs/tools/vep/script/vep_filter.html
@@ -108,7 +113,11 @@ sub new {
   my @files; 
   my $params = $self->params_to_hash();
 
+  my $tr_match = $params->{transcript_match};
+  $self->{transcript_match} = defined $tr_match ? $tr_match : 1;
+
   for my $key (keys %{$params}) {
+    next if $key eq 'transcript_match';
     push @files, $params->{$key};
   }
 
@@ -116,6 +125,10 @@ sub new {
     "  --plugin SpliceVault,file=/path/to/SpliceVault_data_GRCh38.tsv.gz \n"
     unless @files > 0;
   $self->add_file($_) for @files;
+
+  if ((defined $self->{config}->{refseq} || defined $self->{config}->{merged}) && $self->{transcript_match}) {
+    warn "WARNING: SpliceVault transcript_match may fail with --refseq/--merged; consider transcript_match=0\n";
+  }
 
   return $self;
 }
@@ -145,7 +158,9 @@ sub run {
   my @data = @{ $self->get_data($vf->{chr}, $vf->{start} - 2, $vf->{end}) };
 
   foreach (@data) {
-    next unless $tva->transcript->stable_id eq $_->{feature};
+    if ($self->{transcript_match}) {
+      next unless $tva->transcript->stable_id eq $_->{feature};
+    }
 
     my $matches = get_matched_variant_alleles(
       {

--- a/dbNSFP.pm
+++ b/dbNSFP.pm
@@ -592,6 +592,10 @@ sub get_named_params {
   if ($self->{transcript_match} && !defined($self->{transcript_specific_fields})) {
     die("ERROR: transcript_match parameter specified but transcript-specific field detection failed\n");
   }
+
+  if ((defined $self->{config}->{refseq} || defined $self->{config}->{merged}) && $self->{transcript_match}) {
+    warn "WARNING: dbNSFP transcript_match may fail with --refseq/--merged; consider transcript_match=0\n";
+  }
 }
 
 1;

--- a/pLI.pm
+++ b/pLI.pm
@@ -175,6 +175,10 @@ sub new {
     }
     close $fh;
   }
+
+  if ((defined $self->{config}->{refseq} || defined $self->{config}->{merged}) && defined($self->params->[1]) && $self->params->[1] eq 'transcript') {
+    warn "WARNING: pLI transcript mode may fail with --refseq/--merged; consider gene mode\n";
+  }
   
   die("ERROR: No scores read from $file\n") unless scalar keys %scores;
 


### PR DESCRIPTION
https://github.com/Ensembl/VEP_plugins/issues/848
https://github.com/Ensembl/VEP_plugins/issues/849

Some plugins have options to filter result by matching transcript identifier. If used together with --refseq or --merged the matching will fail which may be undesirable. 

We should at least print a warning and have option to not match by transcript id. This PR -
- adds warning messages to such plugins
- for SpliceVault, RiboseqORFs, MPC, and MTR, add option to not match by transcript id as they do not have that. 

Note: Without matching by id the matching would be lenient and should be used with caution.
Note: LOEUF plugin data contains both Ensembl and RefSeq so matching does not affect the result. MaveDB primarily contains refseq identifier in the data and matched by refseq id even for Ensembl transcript, again no affect to the result if --refseq/--merged is used.